### PR TITLE
docs: add full architecture and usage documentation for the playback mod

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,94 @@
+# Playback 架构文档
+
+Playback 是 Minecraft Bedrock Edition 的客户端回放 mod，构建在 [LeviLamina](https://github.com/LiteLDev/LeviLamina) 之上。它能在本地世界或多人服务器录制客户端可见状态，把录制打包成可移植回放文件，并通过主菜单浏览器在隔离的回放世界中播放。回放架构借鉴自 Java 版的 [Flashback](https://github.com/Moulberry/Flashback) 项目。
+
+> 🚀 **一页快速解析**：[overview.md](overview.md) —— 1 张分层架构图 + 1 张录制时序 + 1 张回放时序，5 分钟看完整个项目。
+
+## 快速解析
+
+> 想最短时间理解这个项目？下面这张表先把"做了什么"和"在哪做的"对齐。
+
+| 能力 | 入口 | 关键实现 |
+| --- | --- | --- |
+| 录制世界 | `record start` / `pause` / `stop` 命令 | [functions/record/record.md](functions/record.md) + [overview/record-flow.md](overview/record-flow.md) |
+| 异步落盘 + 区块去重 | 后台 writer 线程 + Snappy 压缩 | [functions/io.md](functions/io.md) |
+| 导出回放 `.zip` | `Recorder::saveRecording` → `ReplayExporter` | [functions/record.md](functions/record.md) |
+| 主菜单打开回放 | `Playback` 按钮 → 回放浏览器 | [screen/replay-browser.md](screen/replay-browser.md) |
+| 在回放世界里回放 | 隔离世界 + Action 重放 + 区块流式注入 | [functions/replay.md](functions/replay.md) + [overview/replay-flow.md](overview/replay-flow.md) |
+| 播放/暂停/seek/变速 | 编辑器上下文状态机 | [editor/context.md](editor/context.md) + [editor/controller.md](editor/controller.md) |
+| 游戏中 ImGui 时间轴 | D3D12 hook + 帧拷贝 | [editor/renderer.md](editor/renderer.md) + [overview/editor-flow.md](overview/editor-flow.md) |
+| 录制/回放的"协议"层 | Action 注册中心 + 二进制协议 | [functions/action.md](functions/action.md) |
+
+> 一个核心心智模型：**Recorder 和 ReplaySession 共享同一套 Action 协议**。录制把游戏事件写成 Action 二进制流；回放从同一份 Action 二进制流重建游戏事件。chunk 走单独的压缩缓存以避免重复写盘。
+
+## 文档地图
+
+```
+docs/
+├── README.md                       本文件（快速解析 + 文档地图）
+├── overview.md                     🚀 一页快速解析（3 张图：分层 + 录制 + 回放）
+├── overview/                       整体视角
+│   ├── architecture.md             分层 + 模块依赖图
+│   ├── record-flow.md              录制时序图
+│   ├── replay-flow.md              回放时序图
+│   └── editor-flow.md              编辑器时序图
+├── playback/                       模组入口
+│   ├── index.md                    Playback 单例 + 生命周期
+│   ├── config.md                   Config 与 CommandConfigStruct
+│   └── lifecycle.md                load/enable/disable/hook/unhook 状态机
+├── command/                        命令层
+│   └── index.md                    playback / record 命令族
+├── functions/                      核心功能
+│   ├── index.md                    总览 + 子模块关系
+│   ├── action.md                   Action 注册中心 + 协议
+│   ├── record.md                   Recorder / ReplayExporter / 录制主流程
+│   ├── io.md                       AsyncReplaySaver / ReplayWriter / ReplayReader / 缓存
+│   ├── replay.md                   ReplaySession 状态机 + 区块流式注入
+│   └── tick.md                     ClientTickHooks
+├── editor/                         回放编辑器
+│   ├── index.md                    编辑器子模块关系图
+│   ├── context.md                  EditorContext 状态机
+│   ├── controller.md               EditorController
+│   ├── renderer.md                 D3D12 钩子 + ImGui 渲染
+│   └── ui.md                       ReplayView / MenuBar / Timeline
+├── screen/                         主菜单
+│   ├── index.md                    主菜单钩子总览
+│   ├── main-menu-hooks.md          MainMenuHooks（按钮 + 弹窗绑定）
+│   └── replay-browser.md           ReplayBrowser（列表/筛选/排序/打开）
+├── utils/                          工具层
+│   ├── index.md
+│   ├── path-utils.md
+│   └── linked-hash-map.md
+└── resources/                      资源与多语言
+    ├── index.md
+    └── ui-pack.md
+```
+
+## 阅读建议
+
+- **5 分钟速通全貌**：[overview.md](overview.md)（一页 + 3 张图）
+- **第一次接触**：先读本文件 → [overview/architecture.md](overview/architecture.md) → [playback/index.md](playback/index.md) → [playback/lifecycle.md](playback/lifecycle.md)
+- **想理解录制**：[overview/record-flow.md](overview/record-flow.md) + [functions/record.md](functions/record.md) + [functions/action.md](functions/action.md) + [functions/io.md](functions/io.md)
+- **想理解回放**：[overview/replay-flow.md](overview/replay-flow.md) + [functions/replay.md](functions/replay.md) + [functions/action.md](functions/action.md)
+- **想理解 UI**：[overview/editor-flow.md](overview/editor-flow.md) + [editor/index.md](editor/index.md) → 各子模块
+- **想理解主菜单入口**：[screen/index.md](screen/index.md) → [screen/replay-browser.md](screen/replay-browser.md)
+
+## 与仓库其它部分的关系
+
+- `README.md` / `README_ZH.md`：面向用户的安装/使用说明
+- `xmake.lua`：构建配置，定义 `levilamina 26.10.*` 依赖和 `imgui dx12` 集成
+- `manifest.json`：LeviLamina 入口声明
+- `resources/`：UI 资源包（[resources/ui-pack.md](resources/ui-pack.md)）
+- `CHANGELOG.md` / `CONTRIBUTING.md`：版本与协作流程
+- `licenses/`：第三方依赖许可
+
+## 关于"模块关系"
+
+本文档不写"按步骤教你做"那种 install/dev 手册。每个模块文档的最后一节固定为"模块关系"，显式列出：
+
+- **被谁调用**：上游触发方
+- **调用谁**：下游依赖
+- **共享数据**：通过事件 / 全局状态 / 单例共享的字段
+- **事件订阅 / 发送**：LeviLamina 事件总线上的订阅关系
+
+这样新人能直接看出"改这里会不会影响别处"。

--- a/docs/command/index.md
+++ b/docs/command/index.md
@@ -1,0 +1,113 @@
+# command
+
+## 职责
+
+注册到 LeviLamina 客户端命令注册器的命令族。命令注册发生在 `ClientCommandRegisterEvent` 事件里，由 `Playback::setupCommands()` 触发。
+
+当前只注册两个族：
+
+- `playback` — 展示 mod 版本
+- `record` — 录制生命周期（`start` / `pause` / `stop`）
+
+`record` 命令族可以被禁用 / 重命名（见 [playback/config.md](../playback/config.md)）。
+
+## 文件
+
+| 文件 | 说明 |
+| --- | --- |
+| `src/playback/command/Command.h` | 两个 `registerXxxCommand` 声明 |
+| `src/playback/command/Command.cpp` | `registerPlaybackCommand` |
+| `src/playback/command/Record.cpp` | `registerRecordCommand` |
+
+## 命令一览
+
+### `playback version`
+
+```text
+playback version
+```
+
+读 `Playback::getInstance().getSelf().getManifest().version`，输出 `v<version>`；不可用时输出 `playback.command.playback.versionUnavailable` 翻译键。
+
+### `record start`
+
+```text
+record start
+```
+
+`Recorder::getInstance().start()`。`start()` 的实际行为：
+
+- `mState == Paused` → 切回 `Recording`，return（不重新 init）。
+- `Playback::isReplayMode()` → 拒绝（mState 置 `Idle`，打 debug 日志）。
+- `mState == Idle` → 调 `resetStateForNewRecording()`（分配 `AsyncReplaySaver`、清理上一会话状态、生成录制玩家 ID），然后 `hookNetwork(true)`，最后置 `Recording`。
+- 其它情况 → 已是 `Recording` / `Closing`，debug 日志忽略。
+
+成功时输出翻译键 `playback.command.record.started`。
+
+### `record pause`
+
+`Recorder::getInstance().pause()`。仅在 `mState == Recording` 时把状态切到 `Paused`。
+
+### `record stop`
+
+`Recorder::getInstance().stop()`。状态机：
+
+- `Idle` → debug 日志忽略，return。
+- `Closing` → debug 日志忽略，return。
+- 其它 → 切到 `Closing`，跑一次 `endTick(true)`，打统计日志，调用 `saveRecording` → `ReplayExporter::exportReplay` → 删除临时目录。
+
+成功时输出翻译键 `playback.command.record.stopped`。
+
+## 注册流程
+
+```mermaid
+sequenceDiagram
+    participant FW as LeviLamina 框架
+    participant Bus as ll::event::EventBus
+    participant PB as Playback
+    participant CR as CommandRegistrar<br/>(ClientInstance)
+    participant Reg as Recorder
+
+    FW-->>Bus: ClientCommandRegisterEvent
+    Bus-->>PB: lambda (在 hook() 中订阅)
+    PB->>PB: setupCommands()
+    PB->>CR: getOrCreateCommand("playback", description)
+    PB->>CR: text("version") overload
+    PB->>CR: getOrCreateCommand("record", description)
+    PB->>CR: text("start") overload -> Recorder::start
+    PB->>CR: text("pause") overload -> Recorder::pause
+    PB->>CR: text("stop") overload -> Recorder::stop
+```
+
+## 翻译键
+
+i18n 键通过 `using ll::i18n_literals::operator""_tr;` 在编译期查表，对应 `src/lang/zh_CN.json` 和 `src/lang/en_US.json`：
+
+- `playback.command.playback.description` / `playback.command.playback.versionUnavailable`
+- `playback.command.record.description` / `playback.command.record.started` / `playback.command.record.paused` / `playback.command.record.stopped`
+
+## 模块关系
+
+### 被谁调用
+
+- `Playback::setupCommands()` 调用 `registerPlaybackCommand` + `registerRecordCommand`。
+- 用户在聊天框输入命令时由 LeviLamina 框架把 overload 调起，最终调 `Recorder` 的方法。
+
+### 调用谁
+
+- `Recorder::getInstance().start/pause/stop`。
+- `Playback::getInstance().getSelf().getManifest()` / `getLogger()`。
+
+### 共享数据
+
+- 通过 `Playback::getConfig().command.record` 读 `enabled` 和命令名（仅 `Record` 族）。
+
+### 事件
+
+- 自身不订阅事件；只在 `ClientCommandRegisterEvent` 中被 `Playback` 间接注册。
+
+## 扩展点
+
+- 新增 overload：在 `registerRecordCommand` 里继续 `recordCommand.overload().text("...")`。
+- 新增命令族：写一个 `registerXxxCommand(...)`（参数按需），在 `Playback::setupCommands()` 调用。
+- 改命令名 / 禁用：编辑 `src/playback/Config.h` 的 `CommandConfigStruct` 默认值。

--- a/docs/editor/context.md
+++ b/docs/editor/context.md
@@ -1,0 +1,153 @@
+# editor/context — UI ↔ Controller 通信协议
+
+> 入口：[`d:\raplay\Playback\src\playback\editor\context\`](file:///d:/raplay/Playback/src/playback/editor/context/)
+> 角色：定义 UI 状态快照 (`EditorState`) 和 UI 指令 (`EditorAction`)，并提供线程安全的 `EditorContext` 作为 controller 与 renderer 之间的中转。
+
+## 内部结构
+
+```
+context/
+├── EditorContext.h / .cpp     ← 线程安全容器：{mutex, state, actions 队列}
+├── EditorState.h              ← UI 显示用的纯数据结构
+└── EditorAction.h             ← UI 想做的事：{type, tick}
+```
+
+## EditorState（UI 看到的快照）
+
+[EditorState.h:5-12](file:///d:/raplay/Playback/src/playback/editor/context/EditorState.h#L5-L12)
+
+```cpp
+struct EditorState {
+    bool  replayVisible{};       // 当前是否在回放世界（replay + 已 join 临时世界）
+    bool  hudVisible{};          // 当前帧 HUD 是否可见（hud 关闭时不画）
+    bool  paused{};              // 当前是否暂停
+    float playbackSpeed{1.0f};   // 当前播放速率
+    int   currentTick{};         // 当前位置
+    int   totalTicks{};          // 总长
+};
+```
+
+**设计要点**：
+
+- **纯数据 + 简单类型**，没有指针 / 引用。`snapshot()` 一次拷贝就够，跨线程安全。
+- **默认值合理**：`playbackSpeed = 1.0f` 是 Unity 编辑器侧的"自然速度"概念。
+- **没有颜色 / 矩形**等 UI 细节：这些是 `ReplayUILayout` 的事。
+
+## EditorAction（UI 想做的事）
+
+[EditorAction.h:5-18](file:///d:/raplay/Playback/src/playback/editor/context/EditorAction.h#L5-L18)
+
+```cpp
+enum class EditorActionType {
+    TogglePause,        // 空格：切换暂停
+    Seek,                // 拖动：跳到指定 tick
+    SkipToStart,         // 跳到开头
+    SkipToEnd,           // 跳到结尾
+    DecreaseSpeed,       // 减速
+    IncreaseSpeed,       // 加速
+    StopReplay,          // 退出回放
+};
+
+struct EditorAction {
+    EditorActionType type{};
+    int              tick{};     // 仅 Seek 使用
+};
+```
+
+**设计要点**：
+
+- **小枚举 + payload**：只有 `Seek` 需要 `tick`，其他枚举的 `tick` 字段被忽略。
+- **控制器不携带数据**：`adjustPlaybackSpeed(±1)` 写在 controller 里，不让 UI 知道新速度是多少。
+- **不直接调 ReplaySession**：UI 只产生 action，controller 负责翻译。
+
+## EditorContext（线程安全中转）
+
+[EditorContext.h:11-27](file:///d:/raplay/Playback/src/playback/editor/context/EditorContext.h#L11-L27)
+
+```mermaid
+flowchart LR
+    subgraph UI["renderer 线程 (D3D Present)"]
+        UI1["snapshot() ← 读 state"]
+        UI2["submit(action) ← push actions"]
+    end
+    subgraph CTRL["主线程 (ClientTickHooks)"]
+        C1["publish(state) ← 写 state"]
+        C2["takeActions() ← drain actions"]
+    end
+    EC["EditorContext<br/>{mutex, mState, mPendingActions}"]
+    UI1 --> EC
+    UI2 --> EC
+    C1 --> EC
+    C2 --> EC
+```
+
+### API
+
+| 方法 | 线程 | 行为 |
+| --- | --- | --- |
+| `snapshot() → EditorState` | UI | 加锁后返回 `mState` 拷贝 |
+| `publish(EditorState)` | Controller | 加锁后 `mState = state`（覆盖，不合并） |
+| `submit(EditorAction)` | UI | 加锁后 `mPendingActions.push_back(action)` |
+| `takeActions() → vector<EditorAction>` | Controller | 加锁后 `swap(mPendingActions)`，返回移动后的队列 |
+| `reset()` | 入口 | 加锁后 `mState = {}; mPendingActions.clear()` |
+
+### 实现细节
+
+[EditorContext.cpp:5-31](file:///d:/raplay/Playback/src/playback/editor/context/EditorContext.cpp#L5-L31)
+
+- **互斥用 `std::scoped_lock`**：自动解锁，对异常安全。
+- **`takeActions` 用 `swap`**：避免逐元素 pop 的拷贝，也保证原队列被清空（O(1)）。
+- **`snapshot` 返回值**：传值返回 = 一次拷贝；如果以后 state 变大可改成 `shared_ptr<EditorState>` 但目前没必要。
+- **`reset`**：在 `hookReplayUI(false)` 时调（[ReplayUI.cpp:65](file:///d:/raplay/Playback/src/playback/editor/ReplayUI.cpp#L65)），把残留的 actions 清掉避免下次回放时旧操作被消费。
+
+## 关键不变量
+
+1. **`actions` 至少延迟一帧**：
+   - UI 在 D3D Present 线程 `submit(action)`，主线程 `tickReplayUI` 在下一次 `endTick` 才 `takeActions()`。
+   - 这是 by design：避免 D3D Present 线程直接调 ReplaySession（线程安全难维护）。
+
+2. **`state` 总是最新的**：
+   - Controller 每次 tick 都会 `publish`，所以即使 actions 队列被清空，UI snapshot 也能反映最新状态。
+
+3. **不会出现"丢失的 action"**：
+   - `swap` 是原子的，UI 在两次 `submit` 之间不会"擦掉"主线程的 `takeActions`。
+   - 但若主线程停在某 tick 太久，UI 仍会持续 push actions（无丢弃），这是允许的（重放语义上"拖到哪就跳到哪"）。
+
+4. **`reset` 只在 hook 卸载时调**：
+   - 正常回放期间 `reset` 不会触发，所以 `state` 保持连续。
+
+## 关键数据结构
+
+| 名称 | 位置 | 大小 | 用途 |
+| --- | --- | --- | --- |
+| `EditorState` | `EditorState.h:5` | ~24B | UI 可见的快照 |
+| `EditorAction` | `EditorAction.h:15` | 8B (4+4) | UI 指令 |
+| `EditorActionType` | `EditorAction.h:5` | 4B | 7 种枚举值 |
+| `mPendingActions` | `EditorContext.h:26` | vector | actions 缓冲 |
+
+## 模块关系
+
+### 被谁调用（上游）
+
+- **`renderer/ImGuiRenderer`**：在 `render()` 中调 `snapshot()`（读 state）和 `submit()`（写 actions）— [ImGuiRenderer.cpp:420,497](file:///d:/raplay/Playback/src/playback/editor/renderer/ImGuiRenderer.cpp)。
+- **`controller/EditorController`**：在 `tick()` 中调 `takeActions()`（读 actions）和 `publish()`（写 state）— [EditorController.cpp:14,47](file:///d:/raplay/Playback/src/playback/editor/controller/EditorController.cpp)。
+- **`ReplayUI`**：构造全局 `gContext`，`hookReplayUI(false)` 时调 `reset()`。
+
+### 调用谁（下游）
+
+- **无**。`EditorContext` 是叶子节点，不依赖任何其他 Playback 模块。
+
+### 共享数据
+
+- **全局 `gContext` 单例**（[ReplayUI.cpp:14](file:///d:/raplay/Playback/src/playback/editor/ReplayUI.cpp#L14)）：整个回放 UI 期间唯一实例。
+
+### 事件订阅 / 发送
+
+- 无。
+
+## 阅读顺序
+
+- 先看本文件理解通信协议
+- 然后看 [controller.md](controller.md) 理解 controller 怎么用这些 API
+- 然后看 [ui.md](ui.md) 理解 UI 怎么产生 actions
+- 最后看 [renderer.md](renderer.md) 理解 D3D Present 线程怎么安全地 snapshot/submit

--- a/docs/editor/controller.md
+++ b/docs/editor/controller.md
@@ -1,0 +1,171 @@
+# editor/controller — Action → ReplaySession 翻译器
+
+> 入口：[`d:\raplay\Playback\src\playback\editor\controller\EditorController.h`](file:///d:/raplay/Playback/src/playback/editor/controller/EditorController.h)
+> 角色：每 tick 把 `EditorContext` 里堆积的 `EditorAction` 翻译成 `ReplaySession` 调用，并把 session 状态打包成 `EditorState` 写回 context。是 UI 与回放会话之间的"翻译官"。
+
+## 内部结构
+
+```
+controller/
+├── EditorController.h    ← 类声明（持 EditorContext&）
+└── EditorController.cpp  ← tick() 主循环
+```
+
+只有一个类：`EditorController`，持 `EditorContext& mContext` 引用。
+
+## tick() 主循环
+
+[EditorController.cpp:11-48](file:///d:/raplay/Playback/src/playback/editor/controller/EditorController.cpp#L11-L48)
+
+```mermaid
+flowchart TB
+    A["tick(hudVisible)"] --> B["takeActions() → [EditorAction, ...]"]
+    B --> C{"遍历每个 action"}
+    C -->|TogglePause| D["session.setPaused(!isPaused())"]
+    C -->|Seek| E["session.requestSeek(action.tick)"]
+    C -->|SkipToStart| F["session.requestSeek(0)"]
+    C -->|SkipToEnd| G["session.requestSeek(getTotalTicks())"]
+    C -->|DecreaseSpeed| H["session.adjustPlaybackSpeed(-1)"]
+    C -->|IncreaseSpeed| I["session.adjustPlaybackSpeed(+1)"]
+    C -->|StopReplay| J["session.requestStop()"]
+    D --> K["打包 EditorState<br/>(从 session 读)"]
+    E --> K
+    F --> K
+    G --> K
+    H --> K
+    I --> K
+    J --> K
+    K --> L["publish(state) → EditorContext"]
+```
+
+### 完整实现
+
+```cpp
+void EditorController::tick(bool hudVisible) {
+    auto& session = functions::ReplaySession::getInstance();
+
+    for (auto const action : mContext.takeActions()) {
+        switch (action.type) {
+        case EditorActionType::TogglePause:  (void)session.setPaused(!session.isPaused()); break;
+        case EditorActionType::Seek:          session.requestSeek(action.tick); break;
+        case EditorActionType::SkipToStart:   session.requestSeek(0); break;
+        case EditorActionType::SkipToEnd:     session.requestSeek(session.getTotalTicks()); break;
+        case EditorActionType::DecreaseSpeed: session.adjustPlaybackSpeed(-1); break;
+        case EditorActionType::IncreaseSpeed: session.adjustPlaybackSpeed(+1); break;
+        case EditorActionType::StopReplay:    session.requestStop(); break;
+        }
+    }
+
+    EditorState state;
+    state.replayVisible = session.isActive() && session.hasJoinedReplayWorld();
+    state.hudVisible    = hudVisible;
+    state.paused        = session.isPaused();
+    state.playbackSpeed = session.getPlaybackSpeed();
+    state.currentTick   = std::max(0, session.getCurrentTick());
+    state.totalTicks    = std::max(0, session.getTotalTicks());
+    mContext.publish(state);
+}
+```
+
+## 关键设计
+
+### 1. 顺序：先处理 actions，再 publish state
+
+```cpp
+for (auto const action : mContext.takeActions()) { ... }   // ① 改 session
+EditorState state; state.x = session....                  // ② 读 session
+mContext.publish(state);                                  // ③ 写回
+```
+
+- 同一 tick 内 actions 的影响在 publish 时已经反映到 state，UI 下次 snapshot 就能看到新值。
+- 不会出现"按了暂停但 UI 还显示播放"的撕裂。
+
+### 2. `replayVisible` 的双条件
+
+```cpp
+state.replayVisible = session.isActive() && session.hasJoinedReplayWorld();
+```
+
+- `isActive()` — ReplaySession 已加载完文件。
+- `hasJoinedReplayWorld()` — 玩家已切到 `__playback_replay_world__` 临时世界。
+- 两条件同时成立才显示 UI（[ImGuiRenderer.cpp:421-425](file:///d:/raplay/Playback/src/playback/editor/renderer/ImGuiRenderer.cpp#L421-L425) 也会用此字段决定 `shutdown`）。
+
+### 3. `TogglePause` 用 `(void)` 显式忽略返回值
+
+```cpp
+case EditorActionType::TogglePause: (void)session.setPaused(!session.isPaused()); break;
+```
+
+- `setPaused` 返回 `bool`（成功 / 失败），但 UI 不需要知道。
+- 显式 `(void)` 让编译器不报 unused-result 警告。
+
+### 4. `currentTick` / `totalTicks` 用 `std::max(0, ...)` 截断
+
+```cpp
+state.currentTick = std::max(0, session.getCurrentTick());
+state.totalTicks  = std::max(0, session.getTotalTicks());
+```
+
+- 防止 `getCurrentTick` 返回负数（idle 状态下）让 ImGui 滑块计算出错。
+- 防御式编程，不依赖 ReplaySession 的契约。
+
+### 5. `hudVisible` 是外参
+
+```cpp
+void tick(bool hudVisible);  // 由 ClientTickHooks 传入
+```
+
+- HUD 不可见时（玩家在聊天框 / 暂停菜单）UI 不画。
+- 决策权交给上游，因为 controller 不直接读 `ClientInstance`。
+
+## 调用映射表
+
+| EditorActionType | EditorController 翻译 | ReplaySession 方法 |
+| --- | --- | --- |
+| `TogglePause` | 取反 | `setPaused(!isPaused())` |
+| `Seek` | 透传 tick | `requestSeek(tick)` |
+| `SkipToStart` | 0 | `requestSeek(0)` |
+| `SkipToEnd` | 当前总长 | `requestSeek(getTotalTicks())` |
+| `DecreaseSpeed` | -1 | `adjustPlaybackSpeed(-1)` |
+| `IncreaseSpeed` | +1 | `adjustPlaybackSpeed(+1)` |
+| `StopReplay` | — | `requestStop()` |
+
+## 关键数据结构
+
+| 名称 | 位置 | 用途 |
+| --- | --- | --- |
+| `EditorController` | `EditorController.h:7` | 单例（`gController`），持 `EditorContext&` |
+| `EditorContext& mContext` | `EditorController.h:14` | 引用全局 `gContext` |
+
+## 模块关系
+
+### 被谁调用（上游）
+
+- **`ReplayUI::tickReplayUI(bool)`**：[ReplayUI.cpp:70](file:///d:/raplay/Playback/src/playback/editor/ReplayUI.cpp#L70) — 每 tick 调一次。
+- **`ReplayUI::hookReplayUI`**：[ReplayUI.cpp:15](file:///d:/raplay/Playback/src/playback/editor/ReplayUI.cpp#L15) — 构造全局 `gController{gContext}`。
+
+### 调用谁（下游）
+
+- **`functions/replay/ReplaySession`**：调 `isActive()` / `hasJoinedReplayWorld()` / `isPaused()` / `getPlaybackSpeed()` / `getCurrentTick()` / `getTotalTicks()` / `setPaused()` / `requestSeek()` / `adjustPlaybackSpeed()` / `requestStop()`。
+- **`context/EditorContext`**：调 `takeActions()` 和 `publish()`。
+
+### 共享数据
+
+- **全局 `gContext`** + **全局 `gController`**（[ReplayUI.cpp:14-15](file:///d:/raplay/Playback/src/playback/editor/ReplayUI.cpp#L14-L15)）。
+
+### 事件订阅 / 发送
+
+- 无。
+
+## 关键不变量
+
+1. **每 tick 最多一次 `takeActions()` 和一次 `publish()`**。多次调用会重复消费 actions（但因为 `swap` 不会出错）。
+2. **`publish` 总是覆盖**：`mState = state` 而非 `merge`。如果以后需要"局部更新"得加新方法。
+3. **`takeActions` 总是清空**：所以如果一帧没消费，下一帧也只看到下一帧的 actions。
+4. **Controller 不缓存 session 指针**：每次 `tick` 都从 `getInstance()` 取，保证不与 ReplaySession 析构/重建冲突。
+
+## 阅读顺序
+
+- 本文件 + [context.md](context.md) — 理解通信协议
+- [replay.md](../functions/replay.md) — 理解 ReplaySession 的方法
+- [ui.md](ui.md) — 理解 UI 怎么产生 action

--- a/docs/editor/index.md
+++ b/docs/editor/index.md
@@ -1,0 +1,174 @@
+# editor — 回放编辑器（ImGui 时间轴 UI）
+
+> 入口：[`d:\raplay\Playback\src\playback\editor\`](file:///d:/raplay/Playback/src/playback/editor/)
+> 角色：在游戏中渲染一个 ImGui 时间轴 UI（菜单栏 + 时间轴 + 控制按钮），让玩家在回放世界内暂停/seek/变速。**只读** `ReplaySession` 状态，**只发** `EditorAction`。
+
+## 内部结构
+
+```
+editor/
+├── ReplayUI.h / .cpp               ← 编辑器入口：组装 + 挂卸所有 hook
+├── context/
+│   ├── EditorContext.h / .cpp      ← 线程安全的状态/动作队列（state + actions）
+│   ├── EditorState.h               ← UI 状态结构（replayVisible/paused/...）
+│   └── EditorAction.h              ← UI → 控制器的指令枚举
+├── controller/
+│   └── EditorController.h / .cpp   ← 每 tick 把 action 转成 ReplaySession 调用
+├── renderer/
+│   ├── D3D12Hooks.h / .cpp         ← Hook IDXGISwapChain::Present + 队列绑定
+│   ├── D3D12Compat.h               ← D3D12 / DXGI 头兼容
+│   ├── ImGuiRenderer.h / .cpp      ← ImGui + ImGui_ImplDX12 初始化 + 帧渲染
+│   └── ReplayMouseHook.h / .cpp    ← 鼠标输入拦截（让 ImGui 收到点击）
+└── ui/
+    ├── ReplayUILayout.h            ← 根据窗口尺寸计算 layout
+    ├── ReplayView.h / .cpp         ← 整体 UI 容器：菜单栏 + 背景图 + 时间轴
+    ├── FormatUtils.h               ← tick ↔ 时分秒格式
+    └── panels/
+        ├── MenuBarPanel.h / .cpp   ← 顶栏（标题 + 速度/退出按钮）
+        └── TimelinePanel.h / .cpp  ← 时间轴 + seek 滑块 + 播放/暂停/跳进退
+```
+
+## 子模块关系图
+
+```mermaid
+flowchart TB
+    subgraph Entry["入口 (per 模组生命周期)"]
+        REPLAYUI["ReplayUI::hookReplayUI()"]
+    end
+
+    subgraph CTX["context/ — 共享状态 (线程安全)"]
+        EC["EditorContext<br/>(mutex + state + actions 队列)"]
+        ES["EditorState<br/>{replayVisible, paused, currentTick, ...}"]
+        EA["EditorAction<br/>(type, tick)"]
+    end
+
+    subgraph CTL["controller/ — 每 tick 调度"]
+        CTRL["EditorController::tick()"]
+    end
+
+    subgraph REN["renderer/ — D3D12 + ImGui 渲染"]
+        D3D["D3D12Hooks<br/>(Present/ResizeBuffers Hook)"]
+        IMG["ImGuiRenderer<br/>(ImGui_ImplDX12 + 帧拷贝 + 提交)"]
+        MOUSE["ReplayMouseHook<br/>(鼠标拦截 + Layout 区域)"]
+    end
+
+    subgraph UI["ui/ — 纯绘制 (无状态)"]
+        VIEW["ReplayView<br/>(drawReplayView 容器)"]
+        LAYOUT["ReplayUILayout<br/>(窗口尺寸 → 矩形)"]
+        MENU["MenuBarPanel"]
+        TL["TimelinePanel"]
+    end
+
+    subgraph EXT["外部"]
+        SESS["ReplaySession<br/>(读: isActive/getCurrentTick/...<br/>写: setPaused/requestSeek/...)"]
+        D3DAPI["IDXGISwapChain<br/>ID3D12CommandQueue"]
+    end
+
+    REPLAYUI -- "构造 gContext+gController" --> EC
+    REPLAYUI -- "setContext" --> IMG
+    REPLAYUI -- "hookD3D12" --> D3D
+    REPLAYUI -- "hookReplayMouse" --> MOUSE
+    REPLAYUI -- "tickReplayUI" --> CTRL
+
+    D3D -- "Present 回调" --> IMG
+    D3D -- "绑定 / 解析" --> D3DAPI
+    IMG -- "snapshot(读)" --> EC
+    IMG -- "submit(写 actions)" --> EC
+    MOUSE -- "鼠标事件" --> IMG
+    IMG -- "drawReplayView" --> VIEW
+    VIEW --> MENU
+    VIEW --> TL
+    VIEW -- "用 layout 算矩形" --> LAYOUT
+
+    CTRL -- "takeActions(读 actions)" --> EC
+    CTRL -- "snapshot(写 state)" --> EC
+    CTRL -- "调 setPaused/requestSeek/..." --> SESS
+```
+
+## 数据流（一次 tick）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Tick as ClientTickHooks
+    participant Ctrl as EditorController
+    participant EC as EditorContext
+    participant Sess as ReplaySession
+    participant DX as D3D12 Present Hook
+    participant Img as ImGuiRenderer
+    participant View as ReplayView
+    participant Mouse as ReplayMouseHook
+
+    Tick->>Ctrl: tick(hudVisible)
+    Ctrl->>EC: takeActions()
+    EC-->>Ctrl: [EditorAction, ...]
+    loop 每个 action
+        Ctrl->>Sess: setPaused / requestSeek / adjustPlaybackSpeed / requestStop
+    end
+    Ctrl->>Sess: isActive / isPaused / getPlaybackSpeed / getCurrentTick / getTotalTicks
+    Ctrl->>EC: publish(EditorState)
+    Note over DX,Img: 接下来 D3D Present 触发
+    DX->>Img: render(swapChain)
+    Img->>EC: snapshot()
+    EC-->>Img: EditorState
+    Img->>Mouse: beginReplayMouseFrame(layout, w, h)
+    Img->>View: drawReplayView(state, layout, actions)
+    View->>View: 画菜单栏 + 背景图 + 时间轴
+    View-->>Img: actions 累加进参数
+    Img->>Mouse: endReplayMouseFrame()
+    Img->>EC: submit(action) for each UI action
+    Img->>DX: ExecuteCommandLists (ImGui_ImplDX12_RenderDrawData)
+    DX-->>DX: 回到 IDXGISwapChain::Present 继续游戏帧
+```
+
+**关键不变量**：
+
+- `EditorContext` 是**唯一**线程间共享的可变状态。
+- `EditorController` 在主线程调 `ReplaySession`；`ImGuiRenderer` 在 D3D Present 线程读 `EditorContext` snapshot。
+- `ImGuiRenderer` 在 UI 帧内 `submit(actions)`；下一帧 `EditorController` 才会 `takeActions()`，所以 actions 至少延迟一帧。
+
+## 子模块索引
+
+| 子模块 | 头文件入口 | 一句话 |
+| --- | --- | --- |
+| ReplayUI | [editor/ReplayUI.h](file:///d:/raplay/Playback/src/playback/editor/ReplayUI.h) | 组装入口：`hookReplayUI` 装/卸所有 hook；`tickReplayUI` 每 tick 调 controller。 |
+| context | [editor/context/EditorContext.h](file:///d:/raplay/Playback/src/playback/editor/context/EditorContext.h) | 状态 + 动作队列的线程安全容器。 |
+| controller | [editor/controller/EditorController.h](file:///d:/raplay/Playback/src/playback/editor/controller/EditorController.h) | 把 UI action 翻译成 `ReplaySession` 调用，并把 session 状态打包成 UI state。 |
+| renderer | [editor/renderer/D3D12Hooks.h](file:///d:/raplay/Playback/src/playback/editor/renderer/D3D12Hooks.h) | 钩 D3D12 + 跑 ImGui。详见 [renderer.md](renderer.md)。 |
+| ui | [editor/ui/ReplayView.h](file:///d:/raplay/Playback/src/playback/editor/ui/ReplayView.h) | 纯绘制：菜单栏 + 背景图 + 时间轴。详见 [ui.md](ui.md)。 |
+
+## 关键设计
+
+1. **状态/动作分离**：`EditorState`（UI 看到的快照）vs `EditorAction`（UI 想做的）。UI 永远只读 state + 写 action，**不直接**调 `ReplaySession`。
+2. **线程边界**：D3D Present 线程写 action，主线程（`ClientTickHooks`）读 action、写 state。两边不直接共享 D3D 资源。
+3. **Hook 失败不致命**：`hookReplayUI` 三个 hook 任意一个失败都 `warn` 继续，UI 可能缺功能但模组其他部分不受影响（[ReplayUI.cpp:34-43](file:///d:/raplay/Playback/src/playback/editor/ReplayUI.cpp#L34-L43)）。
+4. **layout 自适应**：`calculateReplayUILayout(width, height)` 按窗口尺寸算 menuBarHeight / timelineHeight / gameViewport 矩形（[ReplayUILayout.h:17-43](file:///d:/raplay/Playback/src/playback/editor/ui/ReplayUILayout.h#L17-L43)）。
+
+## 模块关系
+
+### 被谁调用（上游）
+
+- **`Playback`**：`enable()` 调 `hookReplayUI(true)`；`disable()` 调 `hookReplayUI(false)`。
+- **`tick/ClientTickHooks`**：每 tick 调 `tickReplayUI(hudVisible)`。
+
+### 调用谁（下游）
+
+- **`functions/replay/ReplaySession`**：controller 直接调它的状态查询和播放控制方法。
+- **D3D12 / DXGI / ImGui**：渲染层直接调 Win32 + D3D12 + ImGui_ImplDX12。
+- **`utils/PathUtils`**：ImGui 初始化用 `GetWindowsDirectoryW()` 加载中文字体 `msyh.ttc`。
+
+### 共享数据
+
+- **`EditorContext` 单例（gContext）**：整个回放 UI 期间唯一共享状态。
+- **`ImGuiRenderer::gImGuiRenderer` 单例**：复用 D3D 资源。
+
+### 事件订阅 / 发送
+
+- **不订阅 LeviLamina 事件总线**。所有逻辑在 D3D Present hook + ClientTick 内部完成。
+
+## 阅读顺序
+
+- 先看本文件 + [renderer.md](renderer.md)（理解 D3D hook + ImGui 怎么跑起来）
+- 然后 [context.md](context.md)（理解 UI ↔ controller 的通信协议）
+- 然后 [controller.md](controller.md)（理解 controller 怎么把 action 翻译成 ReplaySession 调用）
+- 最后 [ui.md](ui.md)（理解具体画什么）

--- a/docs/editor/renderer.md
+++ b/docs/editor/renderer.md
@@ -1,0 +1,289 @@
+# editor/renderer — D3D12 Hook + ImGui 渲染
+
+> 入口：[`d:\raplay\Playback\src\playback\editor\renderer\`](file:///d:/raplay/Playback/src/playback/editor/renderer/)
+> 角色：钩 IDXGISwapChain 的 Present / ResizeBuffers / CreateSwapChain 虚函数，注入 ImGui 渲染管线，让 ImGui 画到游戏帧上面。同时拦鼠标事件，让 ImGui 能收到点击。
+
+## 内部结构
+
+```
+renderer/
+├── D3D12Compat.h            ← D3D12 / DXGI 头兼容
+├── D3D12Hooks.h / .cpp      ← 虚函数表 hook (Present/ResizeBuffers/CreateSwapChain)
+├── ImGuiRenderer.h / .cpp   ← ImGui 上下文 + 帧渲染 + 帧拷贝
+└── ReplayMouseHook.h / .cpp ← 鼠标事件拦截（LL 事件 + 主动 cursor 切换）
+```
+
+## 总流程（D3D Present 一次）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Bgfx as Bgfx D3D12 Backend
+    participant Detour as presentDetour
+    participant Render as ImGuiRenderer
+    participant Ctx as EditorContext
+    participant UI as ReplayView
+    participant Mouse as ReplayMouseHook
+
+    Bgfx->>Detour: IDXGISwapChain::Present(syncInterval, flags)
+    Note over Detour: ActiveDetour 守卫<br/>(防止卸载时还有 Present 飞行)
+    alt 非 DXGI_PRESENT_TEST 且 timeline hooks 未停
+        Detour->>Render: render(swapChain)
+        Render->>Render: 拿 frame index, wait fence
+        Render->>Render: CopyResource(backBuffer → gameTexture)
+        Render->>Ctx: snapshot() → EditorState
+        Render->>Mouse: beginReplayMouseFrame(layout, w, h)
+        Render->>UI: drawReplayView(state, layout, actions)
+        UI->>UI: 画菜单栏 + 时间轴
+        UI-->>Render: actions 数组
+        Render->>Mouse: endReplayMouseFrame()
+        loop 每个 action
+            Render->>Ctx: submit(action)
+        end
+        Render->>Render: ImGui_ImplDX12_RenderDrawData
+        Render->>Render: ExecuteCommandLists + Signal fence
+    end
+    Detour->>Bgfx: origin(swapChain, syncInterval, flags) 继续游戏帧
+    Detour->>Render: afterPresent(swapChain, result)
+    Note over Render: 如果 device removed/reset → shutdown
+```
+
+## D3D12Hooks — 虚函数表 hook
+
+实现见 [D3D12Hooks.cpp:135-174](file:///d:/raplay/Playback/src/playback/editor/renderer/D3D12Hooks.cpp#L135-L174)。
+
+### Hook 入口表
+
+[D3D12Hooks.h:36-43](file:///d:/raplay/Playback/src/playback/editor/renderer/D3D12Hooks.h#L36-L43)
+
+| 虚表下标 | 函数 | Detour |
+| --- | --- | --- |
+| 8 | `IDXGISwapChain::Present` | `presentDetour` |
+| 22 | `IDXGISwapChain1::Present1` | `present1Detour` |
+| 13 | `IDXGISwapChain::ResizeBuffers` | `resizeBuffersDetour` |
+| 39 | `IDXGISwapChain3::ResizeBuffers1` | `resizeBuffers1Detour` |
+| 10 | `IDXGIFactory::CreateSwapChain` | `createSwapChainDetour` |
+| 15 | `IDXGIFactory2::CreateSwapChainForHwnd` | `createSwapChainForHwndDetour` |
+| 16 | `IDXGIFactory2::CreateSwapChainForCoreWindow` | `createSwapChainForCoreWindowDetour` |
+| 24 | `IDXGIFactory2::CreateSwapChainForComposition` | `createSwapChainForCompositionDetour` |
+
+**为什么 hook CreateSwapChain**：Minecraft 在窗口尺寸变化 / 切全屏时会重新创建 swap chain，要在新 swap chain 上重新初始化 ImGui。
+
+### 守卫机制
+
+[D3D12Hooks.cpp:54-74](file:///d:/raplay/Playback/src/playback/editor/renderer/D3D12Hooks.cpp#L54-L74)
+
+```cpp
+std::atomic<uint32_t> gActiveDetours{};
+std::mutex            gActiveDetoursMutex;
+std::condition_variable gActiveDetoursChanged;
+
+class ActiveDetour {
+public:
+    ActiveDetour() { gActiveDetours.fetch_add(1, std::memory_order_acq_rel); }
+    ~ActiveDetour() {
+        if (gActiveDetours.fetch_sub(1, std::memory_order_acq_rel) == 1) gActiveDetoursChanged.notify_all();
+    }
+};
+```
+
+- 每个 detour 入口构造一个 `ActiveDetour`（RAII），退出析构。
+- `hookD3D12(false)` 等待所有 `gActiveDetours == 0` 再卸 hook（`waitForActiveDetours()`）。
+- 防止"正在执行 Present 时被卸 hook"导致崩溃。
+
+### Present Detour 关键点
+
+[present1Detour, D3D12Hooks.cpp:145-174](file:///d:/raplay/Playback/src/playback/editor/renderer/D3D12Hooks.cpp#L145-L174)
+
+```cpp
+bool timelineRendered = false;
+if ((flags & DXGI_PRESENT_TEST) == 0 && !gTimelineHooksStopping.load()) {
+    timelineRendered = gImGuiRenderer.render(swapChain);
+}
+
+DXGI_PRESENT_PARAMETERS fullSurfacePresent{};
+if (timelineRendered && parameters) {
+    fullSurfacePresent = *parameters;
+    fullSurfacePresent.DirtyRectsCount = 0;
+    fullSurfacePresent.pDirtyRects     = nullptr;
+    fullSurfacePresent.pScrollRect     = nullptr;
+    fullSurfacePresent.pScrollOffset   = nullptr;
+    // 把 partial-present 降级为 full-surface-present
+    // 否则 Bgfx 可能用 dirty rect 只更新游戏区域，跳过我们的覆盖
+}
+```
+
+- **`DXGI_PRESENT_TEST` 跳过**：DXGI 在不真正 Present 时会传这个 flag，只画不显示。
+- **partial → full surface**：因为我们改了整张 back buffer 的内容，必须告诉 DXGI "整张都要提交"。
+
+## ImGuiRenderer — 帧渲染
+
+实现见 [ImGuiRenderer.cpp](file:///d:/raplay/Playback/src/playback/editor/renderer/ImGuiRenderer.cpp)。
+
+### 资源初始化（init）
+
+[ImGuiRenderer.cpp:146-358](file:///d:/raplay/Playback/src/playback/editor/renderer/ImGuiRenderer.cpp#L146-L358)
+
+```mermaid
+flowchart TB
+    A["init(swapChain, commandQueue)"] --> B["查 IDXGISwapChain3 + ID3D12Device"]
+    B --> C["device == queue->GetDevice? 否则失败"]
+    C --> D["检查 back buffer 格式 / 尺寸"]
+    D --> E["建 RTV heap + SRV heap"]
+    E --> F["每个 back buffer:<br/>RTV + CommandAllocator + CommandList + gameTexture + SRV"]
+    F --> G["建 Fence + FenceEvent"]
+    G --> H["ImGui::CreateContext()"]
+    H --> I["加载中文字体 msyh.ttc<br/>(GetWindowsDirectoryW)"]
+    I --> J["ImGui_ImplDX12_Init + CreateDeviceObjects"]
+    J --> K["initialized = true"]
+```
+
+**关键点**：
+
+- **每 back buffer 一组资源** (`frames[N]`)，用 `swapChain3->GetCurrentBackBufferIndex()` 索引。
+- **`gameTexture` 是独立 SRV**：先把 back buffer `CopyResource` 到 gameTexture，再把 gameTexture 当 ImGui 全屏背景画（[ImGuiRenderer.cpp:489-493](file:///d:/raplay/Playback/src/playback/editor/renderer/ImGuiRenderer.cpp#L489-L493)），让时间轴 / 菜单栏看起来"在游戏画面上面"。
+- **中文字体 fallback**：`Windows\Fonts\msyh.ttc` 加载失败时降级用 `AddFontDefault`（[ImGuiRenderer.cpp:289-310](file:///d:/raplay/Playback/src/playback/editor/renderer/ImGuiRenderer.cpp#L289-L310)）。
+
+### 帧渲染（render）
+
+[ImGuiRenderer.cpp:414-560](file:///d:/raplay/Playback/src/playback/editor/renderer/ImGuiRenderer.cpp#L414-L560)
+
+```mermaid
+flowchart TB
+    A["render(swapChain)"] --> B["isTimelineRenderingEnabled()?"]
+    B -- no --> X1["return false"]
+    A --> C["editorContext->snapshot()"]
+    C --> D["replayVisible?"]
+    D -- no --> X2["shutdown + return false"]
+    D -- yes --> E["hudVisible?"]
+    E -- no --> X3["关闭鼠标捕获 + return false"]
+    E -- yes --> F["initialized? 否则 init(...)"]
+    F --> G["swapChain3->GetCurrentBackBufferIndex()"]
+    G --> H["waitForFence(frame.fenceValue)"]
+    H --> I["计算 layout = calculateReplayUILayout(w, h)"]
+    I --> J["ImGui_ImplDX12_NewFrame +<br/>beginReplayMouseFrame +<br/>ImGui::NewFrame"]
+    J --> K["GetBackgroundDrawList()->AddImage(gameTexture)"]
+    K --> L["drawReplayView(state, layout, actions)"]
+    L --> M["endReplayMouseFrame + ImGui::Render"]
+    M --> N["for each action: editorContext->submit(action)"]
+    N --> O["ResourceBarrier: backBuffer COPY_SOURCE<br/>+ gameTexture COPY_DEST"]
+    O --> P["CopyResource(backBuffer → gameTexture)"]
+    P --> Q["ResourceBarrier: back → RTV<br/>+ gameTexture → SRV"]
+    Q --> R["OMSetRenderTargets + ClearRenderTargetView"]
+    R --> S["SetDescriptorHeaps + ImGui_ImplDX12_RenderDrawData"]
+    S --> T["ResourceBarrier: backBuffer → PRESENT"]
+    T --> U["ExecuteCommandLists + Signal fence"]
+```
+
+**关键资源屏障序列**（D3D12 资源状态机）：
+
+```
+backBuffer: PRESENT → COPY_SOURCE → RENDER_TARGET → PRESENT
+gameTexture: PIXEL_SHADER_RESOURCE → COPY_DEST → PIXEL_SHADER_RESOURCE
+```
+
+**多缓冲同步**：
+
+- `fenceValue` 记录每个 back buffer 上次 Signal 的值。
+- `waitForFence(value, fence, event)` 阻塞等到 GPU 完成。
+- 防止"上一帧的 command list 还没执行完，CPU 又开始改同一 back buffer"。
+
+### 关停与恢复
+
+[ImGuiRenderer.cpp:562-585](file:///d:/raplay/Playback/src/playback/editor/renderer/ImGuiRenderer.cpp#L562-L585)
+
+- **`beforeResize(swapChain)`** — ResizeBuffers 之前调，shutdown 当前 swap chain 的资源，让 Resize 后 `init` 重新走。
+- **`afterPresent(swapChain, result)`** — Present 之后调，如果 `result == DXGI_ERROR_DEVICE_REMOVED / DEVICE_RESET` → shutdown 并 unbind 队列。
+- **`shutdown()`** — 等待 GPU 完成 → 销毁 ImGui context → 释放 D3D 资源。
+
+## ReplayMouseHook — 鼠标事件拦截
+
+实现见 [ReplayMouseHook.cpp](file:///d:/raplay/Playback/src/playback/editor/renderer/ReplayMouseHook.cpp)。
+
+**两套机制**：
+
+1. **LL 事件总线** [ReplayMouseHook.cpp:66-67](file:///d:/raplay/Playback/src/playback/editor/renderer/ReplayMouseHook.cpp#L66-L67)：
+   ```cpp
+   ll::event::ListenerPtr gMouseInputListener;  // 订阅 MouseInputEvent
+   ll::event::ListenerPtr gKeyInputListener;    // 订阅 KeyInputEvent
+   ```
+   - 当 ImGui 想"捕获鼠标"（`gWantCaptureMouse = true`）时，listener 阻止事件传递给游戏。
+   - 当 ImGui "释放"鼠标时，正常透传。
+
+2. **主动 cursor 切换** [ReplayMouseHook.cpp:60-77](file:///d:/raplay/Playback/src/playback/editor/renderer/ReplayMouseHook.cpp#L60-L77)：
+   ```cpp
+   std::atomic<bool> gCaptureRequested{};
+   std::atomic<bool> gReleaseRequested{};
+   ```
+   - 在 `beginReplayMouseFrame` 时根据 layout 决定"把 cursor 锁进游戏视口矩形"还是"释放到全屏"。
+
+**核心状态机**：
+
+```mermaid
+stateDiagram-v2
+    [*] --> Inactive
+    Inactive --> GameCaptured: hookReplayMouse(true)
+    GameCaptured --> UiReleased: ImGui 不想要鼠标
+    UiReleased --> GameCaptured: ImGui 想捕获
+    GameCaptured --> Inactive: hookReplayMouse(false)
+    UiReleased --> Inactive: hookReplayMouse(false)
+```
+
+**API**（[ReplayMouseHook.h:11-18](file:///d:/raplay/Playback/src/playback/editor/renderer/ReplayMouseHook.h#L11-L18)）：
+
+| 函数 | 调用方 | 作用 |
+| --- | --- | --- |
+| `hookReplayMouse(bool)` | `ReplayUI::hookReplayUI` | 启停 LL 事件订阅 + 状态机 |
+| `setReplayMouseInputActive(bool)` | `ImGuiRenderer` | 通知 mouse hook 接管 / 释放 |
+| `setReplayUIActive(bool)` | `ReplayUI::hookReplayUI` | 整 UI 启停（与 mouse 联锁） |
+| `beginReplayMouseFrame(layout, w, h)` | `ImGuiRenderer::render` | 每帧开头：根据 layout 决定 cursor 矩形 |
+| `endReplayMouseFrame()` | `ImGuiRenderer::render` | 每帧结尾：commit cursor 状态 |
+
+## 关键设计
+
+1. **全屏背景画游戏画面**：`CopyResource` + `AddImage` 让玩家在时间轴/菜单栏里也能看到游戏画面，是"游戏中 UI"的常见做法。
+2. **延迟初始化**：ImGui 资源只在第一次有 `replayVisible + hudVisible` 的帧才创建；replay 退出时 `shutdown`，下次回放再 init。
+3. **多缓冲 fence 同步**：用 `fenceValue` 数组跟踪每 buffer 的 GPU 完成点，避免"back buffer 被复写"导致画面撕裂。
+4. **Hook 失败不致命**：`hookD3D12` / `hookReplayMouse` 失败时 `ReplayUI` 只 warn 不 error，模组主流程继续跑（[ReplayUI.cpp:34-43](file:///d:/raplay/Playback/src/playback/editor/ReplayUI.cpp#L34-L43)）。
+
+## 关键常量
+
+| 名称 | 值 | 位置 | 用途 |
+| --- | --- | --- | --- |
+| `SrvDescriptorCount` | 32 | `D3D12Hooks.h:17` | SRV heap 上限 |
+| `GpuWaitTimeoutMs` | 2000 | `D3D12Hooks.h:18` | fence wait 超时 |
+| `DetourWaitTimeoutMs` | 2000 | `D3D12Hooks.h:19` | hook 卸等待超时 |
+| `SwapChainReplacementDelay` | 500ms | `ImGuiRenderer.cpp:58` | swap chain 替换后最小等待 |
+
+## 模块关系
+
+### 被谁调用（上游）
+
+- **`ReplayUI::hookReplayUI`**：调 `hookRendererInit` / `hookD3D12` / `hookReplayMouse`。
+- **`EditorController` / `ReplayUI::tickReplayUI`**：无直接调用。
+- **`D3D12 Present`**：自动触发 `presentDetour` / `present1Detour`。
+
+### 调用谁（下游）
+
+- **`context/EditorContext`**：调 `snapshot()` / `submit()`。
+- **`ui/ReplayView` / `ReplayUILayout` / `MenuBarPanel` / `TimelinePanel`**：ImGui 帧内调 `drawReplayView`。
+- **LL 事件总线**：`ReplayMouseHook` 订阅 `MouseInputEvent` / `KeyInputEvent`。
+- **D3D12 / DXGI / ImGui / ImGui_ImplDX12**：直接调 Win32 + DXGI + D3D12 + ImGui。
+
+### 共享数据
+
+- **全局 `gImGuiRenderer`**（[ImGuiRenderer.cpp:403](file:///d:/raplay/Playback/src/playback/editor/renderer/ImGuiRenderer.cpp#L403)）：跨函数共享 ImGui 资源。
+- **全局 `gOriginalPresent` 等 8 个 `FuncPtr`**（[D3D12Hooks.cpp:46-53](file:///d:/raplay/Playback/src/playback/editor/renderer/D3D12Hooks.cpp#L46-L53)）：保存原始函数指针。
+- **D3D12 句柄**（device / commandQueue / swapChain3 / RTV heap / SRV heap / fence）存在 `ImGuiRenderer::Impl` 里。
+- **`gSwapChainQueue` 映射**：[D3D12Hooks.h:37-41](file:///d:/raplay/Playback/src/playback/editor/renderer/D3D12Hooks.h#L37-L41) — swap chain → 它的 command queue，ImGui init 用。
+
+### 事件订阅 / 发送
+
+- **订阅** `ll::event::MouseInputEvent` / `KeyInputEvent`（[ReplayMouseHook.cpp:66-67](file:///d:/raplay/Playback/src/playback/editor/renderer/ReplayMouseHook.cpp#L66-L67)）。
+- **不发送**。
+
+## 阅读顺序
+
+- 本文件先看 D3D 钩子表（虚函数下标）+ Present 流程。
+- 然后 [ImGuiRenderer.cpp:414-560](file:///d:/raplay/Playback/src/playback/editor/renderer/ImGuiRenderer.cpp#L414-L560) 看帧渲染。
+- 最后 [ReplayMouseHook.cpp](file:///d:/raplay/Playback/src/playback/editor/renderer/ReplayMouseHook.cpp) 看鼠标拦截状态机。

--- a/docs/editor/ui.md
+++ b/docs/editor/ui.md
@@ -1,0 +1,285 @@
+# editor/ui — 纯绘制层（无状态）
+
+> 入口：[`d:\raplay\Playback\src\playback\editor\ui\`](file:///d:/raplay/Playback/src/playback/editor/ui/)
+> 角色：在每帧的 ImGui 上下文中画菜单栏 + 时间轴，**只读** `EditorState` + **只写** `vector<EditorAction>&`。**不持有任何状态**，不调任何 Playback 业务逻辑。
+
+## 内部结构
+
+```
+ui/
+├── ReplayView.h / .cpp        ← 容器：调 MenuBar + Timeline
+├── ReplayUILayout.h           ← 窗口尺寸 → 矩形 / 比例
+├── FormatUtils.h              ← tick ↔ 时分秒
+└── panels/
+    ├── MenuBarPanel.h / .cpp  ← 顶栏（菜单 + 状态信息）
+    └── TimelinePanel.h / .cpp ← 时间轴（控制按钮 + 进度条 + 标尺）
+```
+
+## 调用关系
+
+```mermaid
+flowchart TB
+    REN["ImGuiRenderer::render()"] --> VIEW["drawReplayView(state, layout, actions)"]
+    VIEW --> MENU["drawMenuBarPanel(state, layout, actions)"]
+    VIEW --> TL["drawTimelinePanel(state, layout, actions)"]
+    LAYOUT["calculateReplayUILayout(w, h)"] --> MENU
+    LAYOUT --> TL
+    FMT["utils::formatTimestamp(tick)"] --> MENU
+    FMT --> TL
+```
+
+**调用顺序固定**：先菜单栏（顶），后时间轴（底），中间是游戏画面背景（由 ImGuiRenderer 的 `AddImage` 画）。
+
+## ReplayView（容器）
+
+[ReplayView.cpp:8-11](file:///d:/raplay/Playback/src/playback/editor/ui/ReplayView.cpp#L8-L11)
+
+```cpp
+void drawReplayView(EditorState const& state, ReplayUILayout const& layout, std::vector<EditorAction>& actions) {
+    drawMenuBarPanel(state, layout, actions);
+    drawTimelinePanel(state, layout, actions);
+}
+```
+
+3 行代码，仅组合。actions 用引用传，两个 panel 各自 push_back 自己的 action。
+
+## ReplayUILayout（窗口尺寸计算）
+
+[ReplayUILayout.h:17-43](file:///d:/raplay/Playback/src/playback/editor/ui/ReplayUILayout.h#L17-L43)
+
+```mermaid
+flowchart TB
+    A["calculateReplayUILayout(displayW, displayH)"] --> B["scale = clamp(displayH/1080, 0.6, 1.5)"]
+    B --> C["menuBarHeight = max(18, 22*scale)"]
+    C --> D["minGameHeight = min(360*scale, displayH*0.6)"]
+    D --> E["timelineHeight = min(250*scale, displayH - menuBar - minGame)"]
+    E --> F["gameViewportTop = menuBarHeight"]
+    F --> G["gameViewportBottom = max(menuBar, displayH - timelineHeight)"]
+    G --> H["gameViewportWidth = min(displayW, gameHeight * aspect)"]
+    H --> I["gameViewportLeft = (displayW - gameViewportWidth)/2 (居中)"]
+    I --> J["返回 ReplayLayout"]
+```
+
+**关键不变量**：
+
+- `menuBarHeight + minGameHeight + timelineHeight ≤ displayHeight`（timelineHeight 可能为 0，如果窗口太小）。
+- `gameViewportWidth` 按宽高比约束，**游戏画面保持原比例**居中显示。
+- `scale` 同时影响 `ImGui::GetIO().FontGlobalScale = max(0.85, layout.scale)`（[ImGuiRenderer.cpp:481](file:///d:/raplay/Playback/src/playback/editor/renderer/ImGuiRenderer.cpp#L481)）。
+
+## MenuBarPanel（顶栏）
+
+[MenuBarPanel.cpp:24](file:///d:/raplay/Playback/src/playback/editor/ui/panels/MenuBarPanel.cpp#L24)
+
+### 内容布局
+
+```mermaid
+flowchart LR
+    M["playback.editor.menu.file"] --> M1["exportVideo (disabled)"]
+    M --> M2["exportScreenshot (disabled)"]
+    M --> M3["openReplay (disabled)"]
+    M --> M4["openRecent (disabled)"]
+    M5["exitReplay (clickable)"]
+    M1 --> SE
+    M2 --> SE
+    M3 --> SE
+    M4 --> SE
+    M5 --> SE["actions.push(StopReplay)"]
+```
+
+**菜单项**（按 MenuBarPanel.cpp:55-94 顺序）：
+
+| i18n key | enabled? | 触发 |
+| --- | --- | --- |
+| `playback.editor.menu.file` (submenu) | — | — |
+| `playback.editor.menu.exportVideo` | ❌ (false) | 暂未实现 |
+| `playback.editor.menu.exportScreenshot` | ❌ | 暂未实现 |
+| `playback.editor.menu.openReplay` | ❌ | 暂未实现 |
+| `playback.editor.menu.openRecent` | ❌ | 暂未实现 |
+| `playback.editor.menu.exitReplay` | ✅ | `StopReplay` action |
+| `playback.editor.menu.preferences` | ❌ | 暂未实现 |
+| `playback.editor.menu.playerList` | ❌ | 暂未实现 |
+| `playback.editor.menu.movement` | ❌ | 暂未实现 |
+| `playback.editor.menu.renderFilter` | ❌ | 暂未实现 |
+| `playback.editor.menu.keybinds` | ❌ | 暂未实现 |
+| `playback.editor.menu.hideReplayUi` | ❌ | 暂未实现 |
+
+> 大量菜单项是占位（`MenuItem(..., false, false)`），未来扩展用。
+
+### 状态栏
+
+[MenuBarPanel.cpp:77-83](file:///d:/raplay/Playback/src/playback/editor/ui/panels/MenuBarPanel.cpp#L77-L83)
+
+```
+Playback  |  <paused/playing>  |  <HH:MM:SS> / <HH:MM:SS>
+```
+
+- `formatTimestamp(currentTick)` 把 tick 换算成时:分:秒（20 tick = 1 秒）。
+- 居右对齐。
+
+## TimelinePanel（时间轴）
+
+[TimelinePanel.cpp:100-...](file:///d:/raplay/Playback/src/playback/editor/ui/panels/TimelinePanel.cpp#L100)
+
+### 布局
+
+```mermaid
+flowchart LR
+    subgraph TL["时间轴窗口 (displayW × timelineHeight)"]
+        LP["左侧控件区 (leftWidth)"]
+        TR["时间轴本体 (timelineWidth)"]
+    end
+    subgraph LP_inner["控件区 (5 个圆按钮)"]
+        S1["⏮ SkipToStart"]
+        S2["🐢 DecreaseSpeed"]
+        S3["⏯ TogglePause"]
+        S4["🐰 IncreaseSpeed"]
+        S5["⏭ SkipToEnd"]
+    end
+    subgraph TR_inner["时间轴本体"]
+        RULER["标尺 + 刻度"]
+        PROG["进度条"]
+        HEAD["播放头"]
+        SCRUB["不可见按钮覆盖整条 (拖动 seek)"]
+    end
+    LP --> LP_inner
+    TR --> TR_inner
+```
+
+**自适应**：
+
+- `leftWidth = clamp(160*scale, 240*scale, displayW*0.42)` — 太小就 5 个按钮变 3 个。
+- `leftWidth < 200*scale` 时只画标尺/进度条，不画控件按钮（[TimelinePanel.cpp:188](file:///d:/raplay/Playback/src/playback/editor/ui/panels/TimelinePanel.cpp#L188)）。
+
+### Scrubbing（拖动 seek）
+
+[TimelinePanel.cpp:152-171](file:///d:/raplay/Playback/src/playback/editor/ui/panels/TimelinePanel.cpp#L152-L171)
+
+```cpp
+static bool scrubbing{};
+static int  scrubTick{};
+static int  committedTick{-1};
+
+ImGui::InvisibleButton("##PlaybackTimelineScrub", ImVec2(timelineWidth, bodyHeight));
+if (ImGui::IsItemActive()) {
+    float const ratio = clamp((io.MousePos.x - timelineLeft) / timelineWidth, 0, 1);
+    scrubTick = clamp(lround(ratio * totalTicks), 0, state.totalTicks);
+}
+if (scrubbing && !ImGui::IsItemActive()) {
+    committedTick = scrubTick;
+    actions.push_back({EditorActionType::Seek, scrubTick});
+}
+scrubbing = ImGui::IsItemActive();
+int const shownTick = scrubActive ? scrubTick : (committedTick >= 0 ? committedTick : state.currentTick);
+```
+
+**3 状态**：
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Scrubbing: 鼠标按下
+    Scrubbing --> Idle: 鼠标松开<br/>(push Seek action)
+    Scrubbing --> Scrubbing: 鼠标拖动<br/>(只更新 scrubTick, 不 push)
+    Idle --> Committed: 刚 push Seek<br/>(committedTick 锁住, 直到 currentTick 追上)
+    Committed --> Idle: state.currentTick == committedTick
+```
+
+- **`scrubTick`**：拖动时实时算的 tick（**不** push action，避免每帧 push 几十个）。
+- **`committedTick`**：拖动结束才 push 一次，UI 暂时显示这个值直到 `currentTick` 真正追上来。
+- **`scrubbing`**：用 static 变量记录"上一帧是否在拖"，检测"鼠标松开"边界（`scrubbing && !active`）。
+
+### 标尺刻度（chooseTimelineScale）
+
+[TimelinePanel.cpp:16-22](file:///d:/raplay/Playback/src/playback/editor/ui/panels/TimelinePanel.cpp#L16-L22)
+
+```cpp
+TimelineScale chooseTimelineScale(int totalTicks, float timelineWidth) {
+    float const targetTicksPerMajor = max(1, totalTicks) * 60.0f / max(1.0f, timelineWidth);
+    if (targetTicksPerMajor < 5.0f)  return {1, 5, true};
+    if (targetTicksPerMajor < 8.0f)  return {2, 5, true};
+    return {max(5, ceil(targetTicksPerMajor / 20.0f) * 5), 4, false};
+}
+```
+
+| 目标主刻度 tick 数 | `ticksPerMinor` | `minorsPerMajor` | `showSubSeconds` |
+| --- | --- | --- | --- |
+| `< 5` | 1 (1 tick 1 minor) | 5 | ✅ |
+| `< 8` | 2 | 5 | ✅ |
+| `≥ 8` | `(⌈target/20⌉)*5` | 4 | ❌ |
+
+**`showSubSeconds`**：画 0.25/0.5/0.75 秒的小刻度线（每 5/10 tick）。
+
+## 自定义绘制原语
+
+[TimelinePanel.cpp:24-98](file:///d:/raplay/Playback/src/playback/editor/ui/panels/TimelinePanel.cpp#L24-L98)
+
+| 函数 | 形状 | 用途 |
+| --- | --- | --- |
+| `drawSkipControl` | 左/右双三角 + 矩形 | ⏮ / ⏭ 跳到头/尾 |
+| `drawRateControl` | 半个三角 (▶ or ◀) | 🐢 / 🐰 减速/加速 |
+| `drawPlaybackAction` | 单三角 (▶) 或 双竖 (⏸) | ⏯ 播放/暂停 |
+| `drawCenteredFittedText` | 自动缩放居中 | 长文本不溢出 |
+
+## FormatUtils（tick ↔ 时间）
+
+[FormatUtils.h:9-22](file:///d:/raplay/Playback/src/playback/editor/ui/FormatUtils.h#L9-L22)
+
+```cpp
+inline std::string formatTimestamp(int ticks) {
+    ticks = max(0, ticks);
+    int const seconds = ticks / 20;       // 20 tick = 1 秒
+    int const minutes = seconds / 60;
+    int const hours   = minutes / 60;
+    if (hours > 0) snprintf("%02d:%02d:%02d", hours, minutes % 60, seconds % 60);
+    else           snprintf("%02d:%02d", minutes, seconds % 60);
+    return string;
+}
+```
+
+- 20 tick/秒 是 Minecraft 标准。
+- 不足 1 小时省略小时位。
+- 用于菜单栏状态栏 + scrubbing tooltip。
+
+## 关键设计
+
+1. **完全无状态**：所有面板只接收 `EditorState` + `ReplayUILayout` + `actions&`，不持任何成员变量（除几个 static 缓存如 `scrubbing` / `committedTick`）。
+2. **i18n 集成**：所有菜单文字用 `"playback.editor.menu.xxx"_tr()` 走 LeviLamina i18n。
+3. **scale 自适应**：`layout.scale` 同时影响字体 / 按钮 / 间距，1080p 基准最大 1.5x、4K 不再放大，720p 最小 0.6x。
+4. **scrubbing 降频**：拖动时只更新本地 `scrubTick`，松手才 push **一次** Seek action，避免 60 Hz 拖动产生几十个 Seek 请求压垮 ReplaySession。
+5. **菜单占位策略**：大量菜单项是 disabled 状态（`MenuItem(..., false, false)`），方便以后扩展但当前不误导用户。
+
+## 关键数据结构
+
+| 名称 | 位置 | 用途 |
+| --- | --- | --- |
+| `ReplayUILayout` | `ReplayUILayout.h:7` | 矩形 / 比例缓存，6 个 float |
+| `TimelineScale` | `TimelinePanel.h:31` | `{ticksPerMinor, minorsPerMajor, showSubSeconds}` |
+| 常量 | `MenuBarPanel.cpp:16-20` | 菜单栏 5 种颜色 |
+
+## 模块关系
+
+### 被谁调用（上游）
+
+- **`renderer/ImGuiRenderer::render`**：调 `drawReplayView(state, layout, actions)` — [ImGuiRenderer.cpp:495](file:///d:/raplay/Playback/src/playback/editor/renderer/ImGuiRenderer.cpp#L495)。
+
+### 调用谁（下游）
+
+- **`context/EditorContext`**：通过 `actions` 引用间接写入，ImGuiRenderer 在帧末统一 `submit`。
+- **ImGui**：直接调 `ImGui::Begin/End/InvisibleButton/MenuItem/SetTooltip` 等。
+- **LL i18n**：用 `"..."_tr()` 取本地化字符串。
+- **`utils::formatTimestamp`**：tick → 时分秒。
+
+### 共享数据
+
+- **无**。面板本身不持任何状态（仅 static 局部缓存）。
+
+### 事件订阅 / 发送
+
+- 无。鼠标事件由 ImGui 内部处理，UI 只看 `io.MousePos` / `IsItemClicked`。
+
+## 阅读顺序
+
+- 本文件理解整体布局。
+- [ReplayUILayout.h:17-43](file:///d:/raplay/Playback/src/playback/editor/ui/ReplayUILayout.h#L17-L43) 理解自适应矩形。
+- [TimelinePanel.cpp:100-...](file:///d:/raplay/Playback/src/playback/editor/ui/panels/TimelinePanel.cpp#L100) 看 scrubbing 状态机。
+- [MenuBarPanel.cpp:24-...](file:///d:/raplay/Playback/src/playback/editor/ui/panels/MenuBarPanel.cpp#L24) 看菜单结构。

--- a/docs/functions/action.md
+++ b/docs/functions/action.md
@@ -1,0 +1,189 @@
+# action — 协议层
+
+`action/` 是录制 / 回放共用的"事件协议"。它把游戏里各种离散事件抽象成 5 个 `Action` 子类，通过 `ActionRegistry` 集中注册，再由 `ReplayWriter` 编码、`ReplayReader` 解码。
+
+## 关键类型
+
+| 类型 | 角色 |
+| --- | --- |
+| `Action` | 抽象基类，每个 Action 有名字 + `handle(ReplaySession&, PlaybackBuffer&)` |
+| `ActionRegistry` | 单例；通过 `name` 索引 `Action*` |
+| `ActionNextTick` | "下一个 tick" 标记（无 payload） |
+| `ActionLevelChunkCached` | 引用 `mChunkPackets[index]` |
+| `ActionSubChunkCached` | 引用 `mChunkPackets[index]` |
+| `ActionGamePacket` | 普通包：`VarInt packetId` + 原始 payload |
+| `ActionMoveEntities` | 实体位姿增量（特化格式，详见下文） |
+
+```mermaid
+classDiagram
+    class Action {
+        <<abstract>>
+        +string name
+        +virtual void handle(ReplaySession&, PlaybackBuffer&)
+    }
+    class ActionRegistry {
+        -vector~unique_ptr~Action~~ mActions
+        -unordered_map~string,Action*~ mNameToAction
+        +registerAction(unique_ptr~Action~)
+        +getAction(string&)
+        +getActions()
+    }
+    class ActionNextTick
+    class ActionLevelChunkCached
+    class ActionSubChunkCached
+    class ActionGamePacket
+    class ActionMoveEntities
+    Action <|-- ActionNextTick
+    Action <|-- ActionLevelChunkCached
+    Action <|-- ActionSubChunkCached
+    Action <|-- ActionGamePacket
+    Action <|-- ActionMoveEntities
+    ActionRegistry --> Action
+```
+
+## 注册表写入顺序敏感
+
+`Playback::registerActions()` 在 mod 启动时按以下顺序写入：
+
+```cpp
+registry.registerAction(std::make_unique<functions::ActionNextTick>());          // id 0
+registry.registerAction(std::make_unique<functions::ActionLevelChunkCached>());  // id 1
+registry.registerAction(std::make_unique<functions::ActionSubChunkCached>());    // id 2
+registry.registerAction(std::make_unique<functions::ActionGamePacket>());        // id 3
+registry.registerAction(std::make_unique<functions::ActionMoveEntities>());      // id 4
+```
+
+`ReplayWriter::writeHeader()` 把 `mActionNameToId[name] = i`（`i` 是注册顺序），把名字列表写入文件头。`ReplayReader` 读回时按相同顺序建立 `id -> Action*` 映射。
+
+> **重要**：不要在不向后兼容的情况下改这个顺序，否则老回放文件读不出来。
+
+## 二进制协议
+
+`AsyncReplaySaver` 写入的每个 chunk 二进制结构（`[ReplayWriter.cpp]`）：
+
+```
+[header]
+  VarInt MAGIC_NUMBER ("LLPB")
+  VarInt actionCount = N
+  N 次：String actionName[i]      // 顺序由 ActionRegistry 决定
+
+[snapshot 区]
+  UInt32 snapshotSize            // 由 startSnapshot/endSnapshot 写回
+  N 个 action：
+    VarInt  actionId
+    UInt32  actionSize           // 由 startAction/finishAction 写回
+    Bytes   actionData           // Action 子类决定格式
+
+[timeline 区（紧接 snapshot 之后）]
+  N 个 action：
+    VarInt  actionId
+    UInt32  actionSize
+    Bytes   actionData
+```
+
+写入约束：
+
+- `startAndFinishAction(Action&)`：用于"没有 payload"的 Action（如 `ActionNextTick`），省略 size 占位。
+- `startAction` / `finishAction`：必须配对使用，size 在 `finishAction` 时回填。
+- `writeHeader` / `popBuffer` 配对：`popBuffer` 写完一个 chunk 后会重新 `writeHeader`，意味着每个 `chunk_N.bin` 都有完整 header。
+
+## 各 Action 的 payload 格式
+
+### `ActionNextTick`（id 0）
+
+无 payload。`handle` 调 `session.handleNextTick()`：`mCurrentTick++`，如果是回放世界并有 `mReplayTime`，会同步 `level.setTime(*mReplayTime)`。
+
+### `ActionLevelChunkCached`（id 1）
+
+```
+VarInt  index   // mChunkPackets[index] 是 FullChunkData payload
+```
+
+`handle` 调 `session.handleLevelChunkCached(index)`：把 index 入 `mPendingLevelChunkIndices` 队列，触发 chunk 注入计划重新准备。
+
+### `ActionSubChunkCached`（id 2）
+
+同 `ActionLevelChunkCached`，但 `mChunkPackets[index]` 是 `SubChunkPacket` payload，handle 入 `mPendingSubChunkIndices`。
+
+### `ActionGamePacket`（id 3）
+
+```
+VarInt  packetId
+Bytes   payload
+```
+
+`handle` 调 `session.handleGamePacket(data)`：
+- 处理中若 `mIsProcessingSnapshot`，`DimensionDataPacket` / `SetTime` 立即应用；其它入 `mPendingSnapshotGamePackets`。
+- 否则直接 `session.applyGamePacket(packetId, payload)`。
+
+### `ActionMoveEntities`（id 4）
+
+支持两种格式（marker 决定）：
+
+**新版（精确位姿）**：
+```
+VarInt  marker = 0
+VarInt  version = 1
+VarInt  count
+count 次：
+  VarInt64  actorUniqueId
+  Float     x, y, z
+  Float     pitch, yaw
+  Float     headYaw, bodyYaw
+  Bool      onGround
+```
+
+**旧版（量化位姿）**：
+```
+VarInt  count  // 非 0 直接走这里
+count 次：
+  VarInt64  actorUniqueId
+  Bool      isPlayer
+  if (isPlayer):
+    Float x, y, z, pitch, yaw, headYaw
+    Bool  onGround
+  else:
+    Byte  header
+    Byte  rotX, rotY, headRotY, bodyRotY
+    Float x, y, z
+```
+
+handle 把"是否在 seek 期间"作为 `snapMovement` 标志位，决定 `MovePlayerPacket` 的 `mResetPosition`（`Normal` / `Teleport`）以及骑乘时的 `RotPrev` 处理。`isRiding()` 的 actor 不发包，直接改组件字段（`ActorRotationComponent` / `ActorHeadRotationComponent` / `MobBodyRotationComponent` / `OnGroundFlagComponent`）。
+
+## `mInjectingPacket` 自识别
+
+`ReplaySession` 用一个 `std::atomic<Packet const*>` 标记"当前是我自己注入的包"。`applyGamePacket` 在 `origin` 前写这个指针、析构时清。`NetworkHooks` 看到 `mInjectingPacket == packet.get()` 时跳过录制 / 不抑制，避免回放自己的包被录两遍。
+
+## 模块关系
+
+### 被谁调用
+
+- `Playback::registerActions()` → `ActionRegistry::registerAction`。
+- `ReplayWriter::writeHeader` → `ActionRegistry::getActions()`（按顺序生成 name 表）。
+- `ReplayReader` 构造时 → `ActionRegistry::getAction(name)`（反查 name → Action*）。
+- `ReplaySession::handleNextAction` / `handleSnapshot` → `Action::handle`。
+- `Recorder::writeTickBoundary` → `ActionNextTick::getInstance()`。
+- `AsyncReplaySaver::writeGamePackets` → `ActionLevelChunkCached` / `ActionSubChunkCached` / `ActionGamePacket` 写时引用。
+
+### 调用谁
+
+- `Action::handle` 调 `ReplaySession` 的 `handleNextTick` / `handleLevelChunkCached` / `handleSubChunkCached` / `handleGamePacket` / `handleMoveEntities`。
+
+### 共享数据
+
+- `ActionRegistry::getInstance()`：进程内唯一。
+- `ReplaySession::mChunkPackets`：`ActionLevelChunkCached` / `ActionSubChunkCached` 引用此数组的 index。
+
+### 事件
+
+- 协议层不订阅 / 发送任何事件。
+
+## 扩展点
+
+- 新增 Action：
+  1. 在 `Action.h` 加 `struct XxxAction : Action { ... getInstance(); }`。
+  2. 在 `Action.cpp` 实现 `XxxAction::handle`。
+  3. 在 `Playback::registerActions()` 末尾 `registry.registerAction(...)`（**注意不要改中间顺序，否则破坏兼容**）。
+  4. 如果有 payload，加进 `ReplayerWriter` / `ReplayReader` 相应的写入/读取路径。
+  5. 在 `ReplaySession` 加对应的 `handleXxx` 方法。
+- 改 Action 协议：保持 `id` 不变是兼容的；改 payload 长度或字段顺序需要写新版本的 reader。

--- a/docs/functions/index.md
+++ b/docs/functions/index.md
@@ -1,0 +1,62 @@
+# functions 总览
+
+`functions/` 是 mod 的核心功能层。涵盖录制（`record`）、回放（`replay`）、协议（`action`）、IO（`io`）、客户端 tick（`tick`）五个子目录。
+
+## 子模块与定位
+
+| 子目录 | 头文件 | 角色 |
+| --- | --- | --- |
+| `action/` | `Action.h` | 录制 / 回放共用的"事件协议"——把游戏事件抽象成离散 `Action`，`ActionRegistry` 集中注册 |
+| `record/` | `Recorder.h` | 录制主循环：状态机 + 玩家 ID 重映射 + snapshot 采集 + 玩家状态写盘 + 导出 |
+| `record/` | `ChunkMutationBarrier.h` | 录制 snapshot 时的 chunk 写互斥屏障 |
+| `record/` | `NetworkHooks.cpp` | LL_TYPE_INSTANCE_HOOK 抓包 + 在回放世界抑制原生 chunk |
+| `record/` | `ReplayExporter.cpp` | 把临时目录 zip 成 `data/replays/<timestamp>.zip` |
+| `io/` | `AsyncReplaySaver.h` | 异步写盘：后台 writer 线程 + snappy 压缩 + chunk 缓存 |
+| `io/` | `ReplayReader.cpp` / `ReplayWriter.cpp` | 二进制回放文件读写 |
+| `io/cache/` | `CachedChunkPacket.h` | `FullChunkData` / `SubChunkPacket` 的去重结构 |
+| `replay/` | `ReplaySession.h` | 回放主循环：状态机 + chunk 流式注入 + 时间轴控制 + 世界清理 |
+| `tick/` | `ClientTickHooks.h` | 钩 `MultiPlayerLevel::_subTick` + `ClientInstance::update`，按 `PlaybackMode` 分发 |
+
+## 子模块关系图
+
+```mermaid
+flowchart LR
+    subgraph Record["录制路径"]
+        NH["NetworkHooks"] -->|recordGamePacket| REC
+        REC["Recorder"] -->|capture| CMB["ChunkMutationBarrier"]
+        REC -->|submit/writeGamePackets| ARS["AsyncReplaySaver"]
+        REC -->|exportReplay| EXP["ReplayExporter"]
+    end
+    subgraph Protocol["协议 / IO"]
+        REG["ActionRegistry"]
+        ARS -->|writer task| RW["ReplayWriter"]
+        RW -->|name -> id| REG
+        ARS -->|chunk 去重| CCP["CachedChunkPacket"]
+    end
+    subgraph Replay["回放路径"]
+        CT["ClientTickHooks"] -->|tickPlayback| REC
+        CT -->|tickPlayback| RS["ReplaySession"]
+        RS -->|reader action| REG
+        REG -->|handleXxx| RS
+        RS -->|injectChunkPacket| NET["LegacyClientNetworkHandler"]
+        NH -->|隔离| NET
+    end
+    subgraph Browser["主菜单"]
+        BROWSER["ReplayBrowser"] -->|openReplay| RS
+    end
+```
+
+## 关键设计
+
+1. **Action 是协议层，不是 IO 层**。`Action` 决定"录制什么事件 / 回放怎么重放"，IO 层只管"字节怎么写 / 怎么读"。改协议改 `Action.h` + 各自的 `handle`，不碰 IO。
+2. **Recorder / ReplaySession 都是单例**。`Recorder::getInstance()` 和 `ReplaySession::getInstance()`。
+3. **AsyncReplaySaver 是生产者-消费者**。录制主线程 `submit(WriteTask)` 入队，后台线程 `pop + execute`。`finish()` 关闭、`cancel()` 删目录。
+4. **ChunkMutationBarrier 是"tick 边界 + 互斥锁"组合**。在 `_subTick` 末尾进入"边界"，所有 chunk 写都延后；`capture` 等待进入边界。
+5. **ClientTickHooks 是"调度器"**。它在 `_subTick` 中按 `PlaybackMode` 决定调 `Recorder::endTick(false)` 还是 `ReplaySession::tick()`；在 `ClientInstance::update` 中调 `tickReplayUI` 和 `tryFinalizeWorldCleanup`。
+
+## 阅读顺序建议
+
+- 想看协议：[action.md](action.md)
+- 想看录制：[record.md](record.md) → [io.md](io.md)
+- 想看回放：[replay.md](replay.md) → [action.md](action.md) → [io.md](io.md)（reader 部分）
+- 想看 tick 调度：[tick.md](tick.md)

--- a/docs/functions/io.md
+++ b/docs/functions/io.md
@@ -1,0 +1,250 @@
+# functions/io — 异步落盘 + 二进制协议 + 区块去重
+
+> 入口：[`d:\raplay\Playback\src\playback\functions\io\`](file:///d:/raplay/Playback/src/playback/functions/io/)
+> 角色：把 `Recorder` 提交的"写任务"异步落盘，并提供 `ReplayReader` 给回放端消费。是 `record` 和 `replay` 共用的"字节层"。
+
+## 内部结构
+
+```
+io/
+├── AsyncReplaySaver.h / .cpp    ← 后台 writer 线程 + 任务队列 + chunk 缓存 + 压缩
+├── ReplayWriter.cpp             ← 写入文件头 / snapshot 块 / action 帧
+├── ReplayReader.cpp             ← 读取文件头 / 解析 snapshot / 顺序读 action
+└── cache/
+    └── CachedChunkPacket.h / .cpp ← LevelChunk / SubChunk 包的两级哈希去重
+```
+
+| 类 | 头文件 | 角色 |
+| --- | --- | --- |
+| `PlaybackBuffer` | `AsyncReplaySaver.h:39` | 继承 `BinaryStream`，增加 `getWritePointer()` / `writeAt(pos, value)`，用于回填"大小字段"。 |
+| `ReplayWriter` | `AsyncReplaySaver.h:63` | 状态机：写头 / 写 snapshot / 写 actions。**所有方法都假设在 saver 后台线程调用**。 |
+| `ReplayReader` | `AsyncReplaySaver.h:98` | 解析单 chunk 文件：头 / snapshot 区 / actions 区。 |
+| `AsyncReplaySaver` | `AsyncReplaySaver.h:124` | 生产者-消费者：主线程 `submit(WriteTask)`，后台线程 `workerLoop()` 串行执行。 |
+| `CachedChunkPacket` | `cache/CachedChunkPacket.h:9` | chunk 包去重：64B SHA3-512 大哈希 + 8B XXH3 长哈希。 |
+| `MAGIC_NUMBER` | `AsyncReplaySaver.h:27` | `0x4C4C5042` ("LLPB")，文件魔数。 |
+| `CHUNK_CACHE_SIZE` | `AsyncReplaySaver.h:28` | 10000 — 单个 chunk cache 文件最大条目数。 |
+
+## 文件结构
+
+`replays/{timestamp}.zip` 内：
+
+```
+zip
+├── metadata.json                        ← PlaybackMeta 的 JSON 序列化
+├── chunk_0.bin                          ← 第 1 个时间片（含 snapshot + actions）
+├── chunk_1.bin
+├── ...
+├── chunk_N.bin                          ← 最后一个时间片
+└── level_chunk_caches/
+    ├── 0.bin                            ← Snappy 压缩后的 LevelChunk/SubChunk 缓存
+    ├── 1.bin
+    └── ...
+```
+
+每个 `chunk_*.bin` 内部：
+
+```
+[文件头  VarInt MAGIC + VarInt actionCount + {actionName  String} × N]
+[VarInt  snapshotSize]
+[snapshot 区: action 帧序列]
+[actions 区: action 帧序列]
+```
+
+**chunk 文件用 LRU 切割**：每 `RECORD_CHUNK_TICKS = 5*60*20` tick 旋转一次，方便 seek 时跳到对应 chunk 再顺序读。
+
+## AsyncReplaySaver（生产者-消费者）
+
+实现见 [AsyncReplaySaver.cpp](file:///d:/raplay/Playback/src/playback/functions/io/AsyncReplaySaver.cpp)。
+
+```mermaid
+flowchart LR
+    subgraph Main["主线程 (录制 tick 内)"]
+        RT["Recorder"]
+        T1["submit(WriteTask)<br/>写入头 / snapshot / tick boundary"]
+        T2["writeGamePackets(SerializedGamePacket)"]
+        T3["writeReplayChunk(chunkName, metadata)"]
+    end
+    subgraph Queue["任务队列"]
+        Q["std::vector<WriteTask><br/>+ std::mutex<br/>+ std::condition_variable"]
+    end
+    subgraph Worker["后台 writer 线程"]
+        WL["workerLoop()"]
+        CHK["写完时调 popBuffer()<br/>并落 chunk_*.bin"]
+        CACHE["mCachedChunkPackets<br/>(去重)"]
+        SNAPPY["writeChunkCacheFile()<br/>snappy::Compress"]
+    end
+    RT --> T1
+    RT --> T2
+    RT --> T3
+    T1 --> Q
+    T2 --> Q
+    T3 --> Q
+    Q --> WL
+    WL --> CACHE
+    WL --> CHK
+    WL --> SNAPPY
+```
+
+**生命周期**：
+
+1. **构造** [AsyncReplaySaver.cpp:40-55](file:///d:/raplay/Playback/src/playback/functions/io/AsyncReplaySaver.cpp#L40-L55)：`PathUtils::createTemp(uuid)` 创建临时目录 → `mReplayWriter.writeHeader()` → `mWorkerThread = std::thread(workerLoop)`。
+2. **运行**：主线程通过 `submit()` / `writeGamePackets()` / `writeReplayChunk()` 提交任务到 `mQueue`，后台线程 `wait + take + execute`。
+3. **完成** `finish()` [AsyncReplaySaver.cpp:141-157](file:///d:/raplay/Playback/src/playback/functions/io/AsyncReplaySaver.cpp#L141-L157)：置 `mRunning = false` + `notify_all` + `join`。
+4. **取消** `cancel()` [AsyncReplaySaver.cpp:159-190](file:///d:/raplay/Playback/src/playback/functions/io/AsyncReplaySaver.cpp#L159-L190)：同上，但额外 `remove_all(mRecordPath)` 删临时目录。
+
+**关键设计**：
+
+- **写任务用 lambda 闭包**：`using WriteTask = std::function<void(ReplayWriter&)>`。主线程不知道"现在写到文件的哪"，后台线程独占 `mReplayWriter` 状态。
+- **chunk 缓存与 actions 分离**：包数据太大（区块可上 MB）不能进 action 帧，所以走独立的 `level_chunk_caches/*.bin`（Snappy 压缩）。action 帧里只写 `VarInt cacheIndex`。
+- **chunk cache 滚动** [AsyncReplaySaver.cpp:202-291](file:///d:/raplay/Playback/src/playback/functions/io/AsyncReplaySaver.cpp#L202-L291)：每 `CHUNK_CACHE_SIZE = 10000` 条目切一个文件，靠 `mCurrentChunkCacheIndex` 跟踪。
+- **错误传播** `recordError()`：把首个错误存进 `mError`，置 `mRunning = false`，清空队列。`getError()` 给主线程查。
+
+## ReplayWriter（写入协议）
+
+实现见 [ReplayWriter.cpp](file:///d:/raplay/Playback/src/playback/functions/io/ReplayWriter.cpp)。
+
+**状态机** [AsyncReplaySaver.h:64-66](file:///d:/raplay/Playback/src/playback/functions/io/AsyncReplaySaver.h#L64-L66)：
+
+```mermaid
+stateDiagram-v2
+    [*] --> EMPTY: writeHeader()
+    EMPTY --> WRITING_SNAPSHOT: startSnapshot()
+    WRITING_SNAPSHOT --> WRITING_DATA: endSnapshot()
+    WRITING_DATA --> WRITING_SNAPSHOT: startSnapshot()<br/>(每个 chunk 多次进入)
+    WRITING_DATA --> [*]: popBuffer() → 落 chunk_*.bin
+```
+
+**写入帧格式**（每个 action 帧）：
+
+```
+VarInt  actionId        // 由 ActionRegistry 的写入顺序决定
+UInt32  dataSize        // 回填：startAction 时占位，finishAction 时 writeAt
+Bytes   actionPayload   // 由 Action::handle 的反向逻辑（即 read 端）决定
+```
+
+**写入帧的层级**：
+
+- `startAndFinishAction(action)` — 简单帧，无 payload（如 `ActionNextTick`）。
+- `startAction(action) + writeXxx + finishAction(action)` — 复合帧，payload 任意字节（如 `ActionGamePacket` / `ActionMoveEntities`）。
+- `startSnapshot() / endSnapshot()` — 包裹一段"snapshot 区"，size 字段回填。
+
+**关键写入路径**（被 `AsyncReplaySaver::writeGamePackets` 间接调用，[AsyncReplaySaver.cpp:202-291](file:///d:/raplay/Playback/src/playback/functions/io/AsyncReplaySaver.cpp#L202-L291)）：
+
+```cpp
+if (MinecraftPacketIds::FullChunkData) {
+    // 走 chunk cache
+    auto cached = CachedChunkPacket(packetId, payload, -1);
+    if (existing in mCachedChunkPackets[longHashCode]) {
+        index = existing.mIndex;            // 命中：复用
+    } else {
+        index = writePacketToCache(payload); // 未命中：写入 mChunkCacheOutput
+        mCachedChunkPackets[longHashCode].push_back(cached);
+    }
+    writer.startAction(ActionLevelChunkCached::getInstance());
+    writer.mStream.writeVarInt(index, nullptr, nullptr);
+    writer.finishAction(ActionLevelChunkCached::getInstance());
+} else if (MinecraftPacketIds::SubChunkPacket) {
+    // 同上但走 ActionSubChunkCached
+} else {
+    // 普通网络包：原样进 actions
+    writer.startAction(ActionGamePacket::getInstance());
+    writer.mStream.writeVarInt(packetId, nullptr, nullptr);
+    writer.mStream.write(payload);
+    writer.finishAction(ActionGamePacket::getInstance());
+}
+```
+
+## ReplayReader（解析协议）
+
+实现见 [ReplayReader.cpp](file:///d:/raplay/Playback/src/playback/functions/io/ReplayReader.cpp)。
+
+**构造时** [ReplayReader.cpp:15-42](file:///d:/raplay/Playback/src/playback/functions/io/ReplayReader.cpp#L15-L42)：
+1. 校验 `MAGIC_NUMBER = 0x4C4C5042`。
+2. 读 `actionCount` 个 action 名，按写入顺序建 `mActionMap: id → Action*`。
+3. 读 `snapshotSize`，记录 `mSnapshotOffset` / `mActionsOffset`。
+
+**`handleSnapshot(ReplaySession&)`** [ReplayReader.cpp:44-78](file:///d:/raplay/Playback/src/playback/functions/io/ReplayReader.cpp#L44-L78)：从 `mSnapshotOffset` 顺序读 actions 直到 `mActionsOffset`，每个 action 通过 `action->handle(session, stream)` 让 `ReplaySession` 处理。
+
+**`handleNextAction(ReplaySession&)`** [ReplayReader.cpp:80-115](file:///d:/raplay/Playback/src/playback/functions/io/ReplayReader.cpp#L80-L115)：单步读一个 action 并分发。
+
+**严格性检查**：
+
+- 包读完后必须 `mReadPointer == mStream.getWritePointer()`，否则抛异常（防协议不一致）。
+- 包 size 不能跨过 `mActionsOffset`。
+- 未知 `actionId` 抛 `Unknow action id`（用 `mLastActionName` 增强错误信息）。
+
+## CachedChunkPacket（chunk 去重）
+
+实现见 [CachedChunkPacket.cpp](file:///d:/raplay/Playback/src/playback/functions/io/cache/CachedChunkPacket.cpp)。
+
+```mermaid
+flowchart LR
+    P["packetId + payload"] --> SHA["OpenSSL EVP_sha3_512<br/>(64 字节)"]
+    SHA --> BIG["mBigHash (64B)"]
+    BIG --> XXH["XXH3_64bits(mBigHash)<br/>(8 字节)"]
+    XXH --> LONG["mLongHashCode (uint64)"]
+    LONG --> BUCKET["mCachedChunkPackets[longHash]<br/>= unordered_map → vector<CachedChunkPacket>"]
+    BUCKET -->|"== 比较"| DUP{"是否已有<br/>完全相同?"}
+    DUP -- yes --> REUSE["复用 mIndex"]
+    DUP -- no  --> APPEND["append + writePacketToCache"]
+```
+
+**两级哈希**：
+
+- **`mBigHash`**：64 字节 SHA3-512，碰撞概率 ~2⁻²⁵⁶，可信度高。
+- **`mLongHashCode`**：8 字节 XXH3，第一级快速过滤。
+
+**operator==** [CachedChunkPacket.cpp:48-51](file:///d:/raplay/Playback/src/playback/functions/io/cache/CachedChunkPacket.cpp#L48-L51)：
+
+```cpp
+bool operator==(const CachedChunkPacket& other) const {
+    if (this->mLongHashCode != other.mLongHashCode) return false; // 快速失败
+    return mBigHash == other.mBigHash;                              // 慢但精确
+}
+```
+
+**为什么不用 `unordered_set`**：因为 `CachedChunkPacket` 含 64B 数组 + index，`std::hash` 算 64B 太慢；`unordered_map<uint64, vector<>>` 让"长哈希相同的桶"用全 64B 比较，兼顾速度和精度。
+
+## 关键常量
+
+| 名称 | 值 | 位置 | 用途 |
+| --- | --- | --- | --- |
+| `MAGIC_NUMBER` | `0x4C4C5042` | `AsyncReplaySaver.h:27` | "LLPB" 文件魔数 |
+| `CHUNK_CACHE_SIZE` | 10000 | `AsyncReplaySaver.h:28` | 单个 chunk cache 文件最大条目数 |
+| `MAX_STRING_LENGTH` | 65536 | `ReplayReader.cpp:13` | 读 action 名时最大长度 |
+
+## 模块关系
+
+### 被谁调用（上游）
+
+- **`record/Recorder`**：通过 `submit()` / `writeGamePackets()` / `writeReplayChunk()` / `finish()` 推任务。
+- **`replay/ReplaySession`**：每个 chunk 通过 `ReplayReader` 解析，触发 `Action::handle` 把 `ActionLevelChunkCached` 等还原为世界包。
+- **`record/ReplayExporter`**：读 `metadata.json` 用的 `PlaybackMeta::fromJson()`（[Recorder.cpp:362-365](file:///d:/raplay/Playback/src/playback/functions/record/Recorder.cpp#L362-L365)），但该方法本身在 `record/`，不在 `io/`。
+
+### 调用谁（下游）
+
+- **`action/ActionRegistry`**：写时按顺序建 `name → id` 映射；读时按 `id → Action*` 反查。
+- **`utils/PathUtils`**：构造时调 `createTemp(uuid)`，saver 文件存到 `dataDir/temp/{uuid}/`。
+- **snappy**：通过 `snappy::Compress()` 压缩 chunk cache。
+- **OpenSSL**：`CachedChunkPacket` 用 `EVP_sha3_512`。
+- **xxHash**：`CachedChunkPacket` 用 `XXH3_64bits`。
+- **BDS `BinaryStream`**：通过 `PlaybackBuffer` 间接使用。
+
+### 共享数据
+
+- **`ActionRegistry` 单例** — 写读两端共用，是协议稳定性的关键。
+- **临时目录** — `PathUtils::getTempPath(uuid)` 与 `PathUtils::getReplaysDir()` 配合：先写临时目录，`Recorder::saveRecording` 再 zip 到 `replays/`。
+
+### 事件订阅 / 发送
+
+- **不订阅 LeviLamina 事件**。纯后台线程 + 条件变量驱动。
+
+## 阅读顺序
+
+- 总体：先看本文件 + [io.md 兄弟文件](action.md)（理解 Action 协议）
+- 异步细节：[AsyncReplaySaver.cpp:40-157](file:///d:/raplay/Playback/src/playback/functions/io/AsyncReplaySaver.cpp#L40-L157)
+- 写入协议：[ReplayWriter.cpp](file:///d:/raplay/Playback/src/playback/functions/io/ReplayWriter.cpp)
+- 读取协议：[ReplayReader.cpp](file:///d:/raplay/Playback/src/playback/functions/io/ReplayReader.cpp)
+- 去重：[CachedChunkPacket.cpp](file:///d:/raplay/Playback/src/playback/functions/io/cache/CachedChunkPacket.cpp)
+- 上游：[record.md](record.md)
+- 下游：[replay.md](replay.md)

--- a/docs/functions/record.md
+++ b/docs/functions/record.md
@@ -1,0 +1,214 @@
+# functions/record — 录制主循环
+
+> 入口：[`d:\raplay\Playback\src\playback\functions\record\`](file:///d:/raplay/Playback/src/playback/functions/record/)
+> 角色：把客户端可见的"游戏事件 + 区块状态"采集成 `Action` 流，交给 `io` 层落盘成可移植回放文件。
+
+## 内部结构
+
+```
+record/
+├── Recorder.h / .cpp           ← 单例：录制状态机 + 写盘协调器
+├── NetworkHooks.cpp            ← LL_TYPE_INSTANCE_HOOK 抓包
+├── ChunkMutationBarrier.h/.cpp ← tick 边界互斥屏障
+└── ReplayExporter.cpp          ← 临时目录 → .zip 打包（声明在 Recorder.h）
+```
+
+| 类 | 头文件 | 角色 |
+| --- | --- | --- |
+| `Recorder` | `Recorder.h:52` | 单例。状态机：Idle / Recording / Paused / Closing。统筹网络包、snapshot、entity movement、tick 边界。 |
+| `ChunkMutationBarrier` | `ChunkMutationBarrier.h:9` | 互斥屏障：保证 snapshot 只在 tick 间隙采集，不与 chunk 写入并发。 |
+| `ReplayExporter` | `Recorder.h:155` | 静态类，把临时目录压缩成 `replays/<timestamp>.zip` 并写入 `metadata.json`。 |
+| `hookNetwork(bool)` | `Recorder.h:167` | 挂/卸所有 `NetworkHooks` + `ChunkMutationBarrier`。 |
+
+## Recorder 状态机
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Recording: start()<br/>(hook 网络包 + 启 AsyncReplaySaver)
+    Recording --> Paused: pause()
+    Paused --> Recording: start()
+    Recording --> Closing: stop()
+    Paused --> Closing: stop()
+    Closing --> Idle: endTick(true)<br/>(写 chunk 文件 + 导出 zip)
+    Recording --> Idle: failRecording()<br/>(cancel 临时目录)
+    Paused --> Idle: failRecording()
+```
+
+实现见 [Recorder.cpp:375-440](file:///d:/raplay/Playback/src/playback/functions/record/Recorder.cpp#L375-L440)（start/pause/stop）、[Recorder.cpp:1450-1474](file:///d:/raplay/Playback/src/playback/functions/record/Recorder.cpp#L1450-L1474)（failRecording/cancelRecording）。
+
+## 录制主循环（endTick）
+
+`endTick(bool close)` 在每个客户端 tick 末尾被 `ClientTickHooks` 触发，是录制所有"边界处理"的统一入口。其内部按顺序执行：
+
+1. `flushGamePackets()` — 把 `mPendingGamePackets` 队列里的网络包写到 `AsyncReplaySaver`。
+2. `writeEntityMovements()` — 对比上一帧 actor 状态，写出变化的 `ActionMoveEntities`。
+3. `writeTickBoundary()` — 写一个 `ActionNextTick`，并标记 `mOpenChunkHasData = true`。
+4. 若达到 `RECORD_CHUNK_TICKS = 20*60*5`（5 分钟）→ 触发 `captureChunkSnapshot()` + `writeSnapshot()` + `commitChunkSnapshot()`，旋转 chunk。
+5. 维度变化 / `close=true` → 调 `finishCurrentChunk(close)` 写 chunk 文件 + metadata。
+6. 首次录制 → 调 `writeInitialSnapshotIfNeeded()` 在第一个 tick 边界采集首帧 snapshot。
+
+实现见 [Recorder.cpp:535-597](file:///d:/raplay/Playback/src/playback/functions/record/Recorder.cpp#L535-L597)。
+
+## Snapshot 采集（captureChunkSnapshot）
+
+**为什么需要它**：世界 chunk 在客户端线程 + 后台 `SubChunk Insert Task Group` 线程同时可能被改；采集时如果不等写入方让开，会读到撕裂的 chunk。
+
+**关键流程**（实现见 [Recorder.cpp:607-1017](file:///d:/raplay/Playback/src/playback/functions/record/Recorder.cpp#L607-L1017)）：
+
+```mermaid
+sequenceDiagram
+    participant R as Recorder
+    participant CMB as ChunkMutationBarrier
+    participant L as MultiPlayerLevel
+    participant T as TaskGroup 线程
+
+    R->>CMB: capture(2s timeout)
+    Note over CMB: 等待 _subTick 末尾<br/>进入 "tick 边界"<br/>(所有 chunk 写暂停)
+    CMB-->>R: CaptureGuard(acquired, waited)
+    R->>L: 读取 dimension.chunkSource.storage
+    L-->>R: 已加载的 LevelChunk 列表
+    par 并行分批（hardware_concurrency）
+        R->>R: 序列化为 LevelChunkPacket
+        R->>R: 序列化为 SubChunkPacket<br/>(按 SubChunkPos 排序)
+        R->>R: 序列化 entity (AddPlayer/AddActor/PlayerList/<br/>MobEquipment/MobArmorEquipment/SetTime)
+    end
+    R->>R: 把 serialized 缓存到 mSnapshot*
+    R-->>R: commitChunkSnapshot(elapsed, barrierWait)
+```
+
+**关键设计**：
+
+- **入口校验** `ChunkMutationBarrier::capture` 返回 `bool`，失败就放弃本帧 snapshot 而不是崩溃。
+- **玩家身份改写** `mRecordedLocalPlayerId/RuntimeId/Uuid` 用三个 `numeric_limits` / 偏移常量作为"虚拟玩家 ID"，让回放世界里本地玩家和原 ID 隔离。
+- **packet 重映射** `remapRecordedPlayerReferences` 处理 16 种会引用玩家 ID 的包（AddPlayer/PlayerList/RemoveActor/Animate/...），让重映射后回放时仍能匹配正确的 actor。
+- **平行序列化** 按 `hardware_concurrency` 分批，每批独立 `SaveContextFactory::createNetworkSaveContext`，避免重复构造。
+
+## NetworkHooks（包捕获）
+
+实现见 [NetworkHooks.cpp:73-264](file:///d:/raplay/Playback/src/playback/functions/record/NetworkHooks.cpp#L73-L264)。
+
+```mermaid
+flowchart LR
+    subgraph Hook["LL_TYPE_INSTANCE_HOOK"]
+        H1["PlaybackPacketReceivedHook<br/>(NetworkStatistics::packetReceivedFrom)"]
+        H2["PlaybackPacketSentHook<br/>(packetSentTo)"]
+        H3["PlaybackAddActorHook<br/>(LegacyClientNetworkHandler::handle)"]
+        H4["PlaybackAddItemActorHook"]
+        H5["PlaybackRemoveActorHook / TakeItemActorHook /<br/>ActorEventHook / LevelEventHook /<br/>UpdateBlockHook / UpdateBlockSyncedHook /<br/>UpdateSubChunkBlocksHook"]
+        H6["PlaybackLevelChunkHook / SubChunkHook"]
+        H7["PlaybackSetTimeHook /<br/>PlaybackChunkHandleCompletedHook"]
+    end
+    H1 --> REC["Recorder::recordGamePacket"]
+    H2 --> REC
+    H3 -. "spawn 后立刻 recordSpawnedActor" .-> REC
+    H4 -. "spawn 后立刻 recordSpawnedActor" .-> REC
+    H5 --> REC
+    H6 -- "录制期" --> REC
+    H6 -- "回放期" --> RS["ReplaySession::shouldIsolateChunkPackets()<br/>+ captureNetworkContext /<br/>isInjectingPacket / shouldSuppressNativeChunk"]
+    H7 -- "回放期才生效" --> RS
+```
+
+**两类钩子并存**：
+
+- **抓包钩子**（recording 时活跃）：所有 hook 都最终调用 `Recorder::recordGamePacket(packet)`，把包原样 push 到 `mPendingGamePackets`。
+- **回放隔离钩子**（replay 时活跃）：当 `ReplaySession::shouldIsolateChunkPackets()` 返回 true，钩子会**过滤**掉非回放注入的 chunk 包，避免与回放世界冲突。
+- **状态机** `NetworkHookState`（[NetworkHooks.cpp:38-64](file:///d:/raplay/Playback/src/playback/functions/record/NetworkHooks.cpp#L38-L64)）记录 15 个 hook 的安装/卸载状态，`hookNetwork(true/false)` 原子切换。
+
+**`recordGamePacket` 关键过滤**（[Recorder.cpp:1329-1408](file:///d:/raplay/Playback/src/playback/functions/record/Recorder.cpp#L1329-L1408)）：
+
+| 条件 | 行为 |
+| --- | --- |
+| `AddActor.mEntityData == nullptr` | 跳过（半成品） |
+| `AddItemActor.mEntityData == nullptr` | 跳过 |
+| `FullChunkData.mCacheEnabled == true` | 跳过（已缓存的不重复写） |
+| `SubChunkPacket.mCacheEnabled == true` | 跳过 |
+| `MoveAbsoluteActor / MovePlayer / NetworkChunkPublisherUpdate / ChunkRadiusUpdated` | 跳过（不参与回放，snapshot 已经包含实体位置） |
+| `DimensionDataPacket` | 始终记录（即使 Idle 状态也要记到 mDimensionDataPayload） |
+| 包引用本地玩家 ID | 用 `remapRecordedPlayerReferences` 改写 |
+
+## ChunkMutationBarrier（tick 边界互斥）
+
+实现见 [ChunkMutationBarrier.cpp](file:///d:/raplay/Playback/src/playback/functions/record/ChunkMutationBarrier.cpp)。
+
+**三组机制**：
+
+1. **`TickBoundaryGuard`**：在 `MultiPlayerLevel::_subTick` 末尾进入 / 离开时构造/析构。`tickBoundaryLevel` 线程局部变量记录"当前线程是否在边界内"。
+2. **`CaptureGuard`**：`capture(2s timeout)` 用 `std::timed_mutex` 阻塞等待；返回 `{acquired, waited}`。
+3. **后台写入拦截**：hook `TaskGroup` 的 vtable，发现属于 `SubChunk Insert Task Group` 的后台线程在写 chunk 时，**延后**到下一个 tick 边界。
+
+```cpp
+// Recorder.cpp 简化片段
+auto mutationGuard = ChunkMutationBarrier::capture();
+if (!mutationGuard) { failRecording("...barrier"); return; }
+auto* guardedPlayer = clientInstance->getLocalPlayer();
+if (guardedPlayer != localPlayer || ...) { failRecording("player/dim changed"); return; }
+// 此处：tick 已切换完，chunk 写入线程被挡住，可以安全地遍历 storage
+```
+
+## ReplayExporter（导出 zip）
+
+实现见 [Recorder.cpp:155-165](file:///d:/raplay/Playback/src/playback/functions/record/Recorder.cpp) 声明 + [ReplayExporter.cpp](file:///d:/raplay/Playback/src/playback/functions/record/ReplayExporter.cpp) 实现。
+
+```mermaid
+flowchart LR
+    A["stop()"] --> B["AsyncReplaySaver::finish()"]
+    B --> C["join worker thread"]
+    C --> D["返回临时目录路径"]
+    D --> E["ReplayExporter::exportReplay(tempDir, zipPath, name)"]
+    E --> F["读取 metadata.json<br/>(PlaybackMeta::fromJson)"]
+    E --> G["打包 zip:<br/>chunk_*.bin + level_chunk_caches/*.bin<br/>+ metadata.json + screenshots/*"]
+    E --> H["replays/{timestamp}.zip 或 {timestamp} (n).zip"]
+```
+
+**关键点**：
+
+- 文件名生成 `findAvailableReplayName(replayDir, currentReplayTimestampName())`：先尝试 `2026-07-29T12-34-56.zip`，冲突则 `2026-07-29T12-34-56 (1).zip`，最多 10000 次，最后兜底用 UUID。
+- `metadata.json` 由 `PlaybackMeta::toJson()`（[Recorder.cpp:295-321](file:///d:/raplay/Playback/src/playback/functions/record/Recorder.cpp#L295-L321)）序列化：`name` / `worldName` / `duration` / `totalTicks` / `initialView{x,y,z,yaw,pitch}` / `chunks: { chunkName -> chunkMeta }`。`chunks` 字段用 `LinkedHashMap` 保序。
+
+## 关键数据结构
+
+| 名称 | 位置 | 用途 |
+| --- | --- | --- |
+| `PlaybackView` | `Recorder.h:30` | 玩家视角 (x,y,z,yaw,pitch)，作为初始视角 / chunk 起点 |
+| `PlaybackMeta` | `Recorder.h:38` | 回放元数据 + 嵌套的 chunk 元数据树 |
+| `PlaybackSerializedGamePacket` | `AsyncReplaySaver.h:34` | 已序列化的网络包 `{packetId, payload}`，跨线程传递 |
+| `State` 枚举 | `Recorder.h:54` | Idle / Recording / Paused / Closing |
+| 常量 | `Recorder.h:93` | `RECORD_CHUNK_TICKS = 20*60*5` = 5 分钟一个 chunk |
+| 常量 | `Recorder.cpp:87-88` | 录制玩家的虚拟 ID（避免与原 ID 冲突） |
+
+## 模块关系
+
+### 被谁调用（上游）
+
+- **`command::record`**：调 `start()` / `pause()` / `stop()`。
+- **`Playback::isReplayMode()`**：`start()` 里检查，回放世界不允许开始录制。
+- **`ClientTickHooks`**：每 tick 调 `endTick(false)`，stop 时调 `endTick(true)`。
+
+### 调用谁（下游）
+
+- **`functions::action::ActionRegistry`**：通过 `ActionNextTick` / `ActionGamePacket` / `ActionMoveEntities` / `ActionLevelChunkCached` / `ActionSubChunkCached` 的 `startAndFinishAction` / `startAction` 写入。
+- **`functions::io::AsyncReplaySaver`**：调 `submit()` / `writeGamePackets()` / `writeReplayChunk()`，并最终调 `finish()`。
+- **`utils::PathUtils`**：调 `getReplaysDir()` 决定 zip 存放位置；`createTemp` 给 saver 用。
+- **`functions::replay::ReplaySession`**：`NetworkHooks` 在回放期通过 `shouldIsolateChunkPackets()` / `shouldSuppressNativeChunk()` / `isInjectingPacket()` / `onLevelChunkHandled()` 与 ReplaySession 双向通信。
+- **MinecraftPackets / NetworkStatistics / ClientInstance / LocalPlayer / Dimension / SubChunk** 等 BDS 内部类型（深度耦合）。
+
+### 共享数据
+
+- **`ActionRegistry` 单例** — 录制时写入，回放时读取。
+- **`mAsyncReplaySaver` 唯一实例** — 通过 `submit` 闭包把 lambda 跨线程传到后台 writer 线程。
+- **`mRecordedLocalPlayerId/RuntimeId/Uuid`** — 录制时设置的虚拟 ID，序列化时把原包里的玩家 ID 改写为虚拟 ID；回放世界重启时回放端会用相同 ID 重建。
+
+### 事件订阅 / 发送
+
+- **不订阅 LeviLamina 事件总线**。所有捕获完全靠 LL_TYPE_INSTANCE_HOOK 拦截 NetworkStatistics + LegacyClientNetworkHandler + ClientNetworkHandler + MultiPlayerLevel 的虚函数。
+
+## 阅读顺序
+
+- 状态机骨架：先看本文件 + [Recorder.cpp:375-597](file:///d:/raplay/Playback/src/playback/functions/record/Recorder.cpp#L375-L597)
+- snapshot 细节：本文件 + [Recorder.cpp:607-1017](file:///d:/raplay/Playback/src/playback/functions/record/Recorder.cpp#L607-L1017)
+- 包抓取：本文件 + [NetworkHooks.cpp](file:///d:/raplay/Playback/src/playback/functions/record/NetworkHooks.cpp)
+- 互斥屏障：本文件 + [ChunkMutationBarrier.cpp](file:///d:/raplay/Playback/src/playback/functions/record/ChunkMutationBarrier.cpp)
+- 异步落盘：[io.md](io.md)
+- Action 协议：[action.md](action.md)
+- tick 调度：[tick.md](tick.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,212 @@
+# Playback 快速解析（一页）
+
+> 目标：用一张图看清全貌，用两张时序图看清录制与回放的关键路径。
+
+---
+
+## 1. 分层架构（模块关系总览）
+
+```mermaid
+flowchart TB
+    subgraph ENTRY["入口层"]
+        MOD["Playback (单例)"]
+        CFG["PlaybackConfig"]
+        LIFECYCLE["lifecycle<br/>load / enable / disable"]
+    end
+
+    subgraph CMD["命令层"]
+        PCMD["playback version"]
+        RCMD["record start/pause/stop"]
+    end
+
+    subgraph CORE["核心功能层 functions/"]
+        REC["record/<br/>Recorder · NetworkHooks<br/>ChunkMutationBarrier<br/>AsyncReplaySaver"]
+        REP["replay/<br/>ReplaySession · ReplayDriver<br/>ReplayWorldManager"]
+        ACT["action/<br/>Action · ActionRegistry"]
+        IO["io/<br/>ReplayWriter · ReplayReader<br/>CachedChunkPacket · Snappy"]
+        TICK["tick/<br/>TickScheduler"]
+    end
+
+    subgraph EDITOR["编辑器层 editor/"]
+        ECTX["context<br/>EditorContext · EditorState"]
+        ECTL["controller<br/>时间轴 / 播放控制"]
+        EREN["renderer<br/>D3D12 Hook · ImGui 渲染"]
+        EUI["ui/<br/>Timeline / 面板"]
+    end
+
+    subgraph SCREEN["界面集成层 screen/"]
+        MMH["main-menu-hooks<br/>主菜单按钮挂载"]
+        RB["replay-browser<br/>回放列表 / 启动回放"]
+    end
+
+    subgraph UTIL["工具层 utils/"]
+        PATH["PathUtils<br/>replays / temp 目录"]
+        LHM["LinkedHashMap<br/>保序哈希表"]
+    end
+
+    subgraph RES["资源层 resources/"]
+        UIPACK["ui-pack<br/>按钮 / 图标 资源包"]
+    end
+
+    MOD --> CFG
+    MOD --> LIFECYCLE
+    LIFECYCLE --> CMD
+    LIFECYCLE --> EDITOR
+    LIFECYCLE --> SCREEN
+
+    CMD --> REC
+    CMD --> REP
+
+    REC -- "Action 事件流" --> ACT
+    REC -- "异步落盘 + Snappy" --> IO
+    ACT -- "注册 / 序列化 / 反序列化" --> IO
+    REP -- "读取 Action" --> IO
+    REP -- "Action.handle()" --> ACT
+    REP --> TICK
+    TICK --> REC
+
+    EDITOR -- "查询 / 控制" --> REP
+    EUI --> EREN
+    ECTL --> ECTX
+    EREN -- "D3D12 Present Hook" --> EUI
+
+    SCREEN -- "打开回放浏览器" --> RB
+    RB -- "创建 ReplaySession" --> REP
+
+    REC --> PATH
+    IO --> PATH
+    LHM -. "REC / IO 内部容器" .- REC
+    LHM -. "REC / IO 内部容器" .- IO
+    MMH --> UIPACK
+```
+
+**关键关系一句话**
+
+- `Playback` 是一切的总开关，初始化 `ActionRegistry`、挂 D3D12 Hook、注册命令、创建主菜单按钮。
+- `Recorder` 只生产 `Action`；`ReplaySession` 只消费 `Action`；两者共享 `ActionRegistry` + `io` 层的二进制协议。
+- `editor/` 永远不直接动世界数据，只读 `ReplaySession` 状态 + 调控制器。
+- `utils/` 是被所有上层调用的基础服务，不反向依赖任何上层。
+
+---
+
+## 2. 录制时序（record flow）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as 用户
+    participant CMD as record 命令
+    participant R as Recorder
+    participant NH as NetworkHooks
+    participant BAR as ChunkMutationBarrier
+    participant AR as AsyncReplaySaver
+    participant FS as 磁盘 (Snappy)
+
+    U->>CMD: record start
+    CMD->>R: begin()
+    R->>AR: open(replays/{uuid})
+    AR->>FS: 写文件头 + ActionRegistry 名表
+    NH-->>R: onPacket(packetId, payload)
+    R->>R: 写入 ActionNextTick (tick 边界)
+    R->>BAR: waitUntilSafeToCapture()
+    BAR-->>R: tick 切换瞬间解锁
+    R->>AR: write(ChunkCached / SubChunkCached)
+    AR->>FS: 后台线程：Snappy 压缩 + 落盘
+    Note over AR,FS: CachedChunkPacket 去重同区块
+    U->>CMD: record stop
+    CMD->>R: end()
+    R->>AR: close()
+    AR->>FS: 写入 snapshot 块 + finalize zip
+```
+
+**要点**
+
+- **tick 边界** 是唯一允许捕获区块快照的时刻（`ChunkMutationBarrier`）。
+- **网络包** 由 `NetworkHooks` 旁路捕获，按原始 packetId 写入 `ActionGamePacket`，不做解析。
+- **去重**：`CachedChunkPacket` 用 64 字节大哈希 + 64 位长哈希两级去重。
+- **落盘异步**：`AsyncReplaySaver` 跑独立线程，主线程只 push 数据。
+
+---
+
+## 3. 回放时序（replay flow）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as 用户
+    participant RB as replay-browser
+    participant RWM as ReplayWorldManager
+    participant IO as ReplayReader
+    participant RS as ReplaySession
+    participant ACT as ActionRegistry
+    participant W as 临时回放世界
+
+    U->>RB: 选择回放
+    RB->>RWM: createSpectatorWorld("__playback_replay_world__")
+    RWM-->>U: 进入临时世界
+    RB->>RS: load(path)
+    RS->>IO: open + 读头 / 读 snapshot
+    IO-->>RS: 快照区块数据
+    RS->>W: injectSnapshot(区块)
+    loop 每个 tick
+        RS->>IO: readActions()
+        IO-->>RS: Action 列表
+        loop 每个 Action
+            RS->>ACT: getAction(id)
+            ACT-->>RS: Action 实例
+            RS->>ACT: handle(session, payload)
+            ACT->>W: replay packet / move entities / cache chunk
+        end
+    end
+    U->>RB: 退出回放
+    RB->>RWM: destroySpectatorWorld()
+    RWM-->>U: 返回原世界
+```
+
+**要点**
+
+- **世界隔离**：`__playback_replay_world__` 前缀的临时观察者世界，退出即销毁，不污染主存档。
+- **回放不解析业务包**：`ActionGamePacket` 在 `ActionRegistry` 查表后用 LeviLamina 提供的 `sendNetworkPacket` 注入，让客户端自己解析。
+- **确定性回放**：`ActionNextTick` 控制时间推进，保证 tick 序号与录制严格一致。
+
+---
+
+## 模块索引（速查）
+
+| 模块 | 路径 | 一句话职责 |
+|---|---|---|
+| `Playback` | `playback/Playback.h` | 单例总入口，串联所有子系统 |
+| `PlaybackConfig` | `playback/config.h` | 命令开关 / 重命名静态配置 |
+| `command` | `playback/command/` | `playback` 与 `record` 命令注册 |
+| `functions/record` | `playback/functions/record/` | 录制状态机 + 网络旁路 + 异步落盘 |
+| `functions/replay` | `playback/functions/replay/` | 回放会话 / 驱动 / 临时世界管理 |
+| `functions/action` | `playback/functions/action/` | 5 类 Action 协议 + 注册表 |
+| `functions/io` | `playback/functions/io/` | 二进制读写 + 缓存 + Snappy |
+| `functions/tick` | `playback/functions/tick/` | tick 调度（录制/回放共用） |
+| `editor` | `playback/editor/` | ImGui 时间轴 UI（context / controller / renderer / ui） |
+| `screen` | `playback/screen/` | 主菜单按钮 + 回放浏览器 |
+| `utils` | `playback/utils/` | `PathUtils` / `LinkedHashMap` |
+| `resources` | `playback/resources/` | UI 资源包（按钮 / 图标） |
+
+---
+
+## 依赖方向（自上而下，不允许反向）
+
+```
+playback (入口)
+  ├─ command
+  ├─ editor
+  ├─ screen
+  └─ functions/
+       ├─ record ──► action ◄── replay
+       │             │           │
+       │             ▼           │
+       └───────────  io  ◄───────┘
+                    │
+                    ▼
+                  utils
+```
+
+- `record` 与 `replay` 是平行模块，**只通过 `action` + `io` 对接**。
+- `editor` 只能依赖 `replay`（读状态 / 控播放），不能碰 `record`。
+- `utils` 是叶子节点。

--- a/docs/overview/architecture.md
+++ b/docs/overview/architecture.md
@@ -1,0 +1,176 @@
+# 整体架构
+
+## 分层视角
+
+Playback 的代码按"层次"组织，层次之间通过 LeviLamina 事件总线 + C++ 单例 + 显式函数调用三种方式连接。从外到内大致是：
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│ 用户交互层                                                                │
+│   - 客户端命令:  command/*                                                │
+│   - 主菜单:       screen/* (MainMenuHooks + ReplayBrowser)                │
+│   - 游戏中 UI:   editor/* (ReplayUI + EditorContext + ImGui 渲染)         │
+└────────────────────────────────────────────────────────────────────────┘
+                                  │
+                                  ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│ 入口 / 生命周期                                                            │
+│   - playback::Playback  (PIMPL 单例)                                      │
+│   - Config / hook / unhook / refreshMode / enable / disable               │
+└────────────────────────────────────────────────────────────────────────┘
+                                  │
+            ┌─────────────────────┼─────────────────────┐
+            ▼                     ▼                     ▼
+┌─────────────────────┐ ┌─────────────────────┐ ┌─────────────────────┐
+│ 录制路径            │ │ 回放路径             │ │ UI 渲染路径          │
+│ Recorder            │ │ ReplaySession       │ │ EditorController    │
+│ ReplayExporter      │ │ ReplayReader        │ │ ImGuiRenderer       │
+│ NetworkHooks        │ │ ClientTickHooks     │ │ D3D12Hooks          │
+│ ChunkMutationBarrier│ │ Chunk 流式注入       │ │ ReplayMouseHook     │
+└─────────────────────┘ └─────────────────────┘ └─────────────────────┘
+            │                     │                     │
+            └──────────┬──────────┴──────────┬──────────┘
+                       ▼                     ▼
+        ┌────────────────────────┐ ┌──────────────────────┐
+        │ 协议层: Action + IO     │ │ 工具 / 资源          │
+        │ ActionRegistry          │ │ PathUtils            │
+        │ AsyncReplaySaver        │ │ LinkedHashMap        │
+        │ ReplayWriter / Reader   │ │ UI 资源包            │
+        │ CachedChunkPacket       │ │ i18n (en_US/zh_CN)   │
+        └────────────────────────┘ └──────────────────────┘
+```
+
+## 模块依赖图
+
+```mermaid
+flowchart TB
+  subgraph UI["用户入口"]
+    CMD["command::*"]
+    MENU["screen::MainMenuHooks"]
+    BROWSER["screen::ReplayBrowser"]
+    REPLAY_UI["editor::ReplayUI<br/>(gContext + gController)"]
+  end
+
+  subgraph ENTRY["入口"]
+    PB["playback::Playback<br/>(PIMPL 单例)"]
+    CFG["Config"]
+    LIFE["hook / unhook /<br/>refreshMode / mode"]
+  end
+
+  subgraph REC["录制"]
+    REC_INST["Recorder::getInstance()"]
+    NH["NetworkHooks<br/>(LL_TYPE_INSTANCE_HOOK)"]
+    CMB["ChunkMutationBarrier"]
+    EX["ReplayExporter"]
+  end
+
+  subgraph RPL["回放"]
+    RS["ReplaySession::getInstance()"]
+    RR["ReplayReader<br/>(多个 reader / chunk)"]
+    CT["ClientTickHooks"]
+  end
+
+  subgraph PROTOCOL["协议 / IO"]
+    REG["ActionRegistry::getInstance()"]
+    ARS["AsyncReplaySaver<br/>(后台 writer 线程)"]
+    RW["ReplayWriter"]
+    CCP["CachedChunkPacket"]
+  end
+
+  subgraph EDITOR["编辑器"]
+    EC["EditorContext<br/>(状态机)"]
+    ECTRL["EditorController"]
+    IR["ImGuiRenderer<br/>(gImGuiRenderer)"]
+    D3D["D3D12Hooks"]
+    RMH["ReplayMouseHook"]
+    VIEW["ui::ReplayView<br/>MenuBar / Timeline"]
+  end
+
+  subgraph UTIL["工具"]
+    PU["utils::PathUtils"]
+    LHM["utils::container::LinkedHashMap"]
+  end
+
+  CMD -->|start/pause/stop| REC_INST
+  MENU -->|hook 注入| BROWSER
+  BROWSER -->|openReplay| RS
+  BROWSER -->|scan dir| PU
+
+  PB -->|setupCommands| CMD
+  PB -->|registerActions| REG
+  PB -->|refreshMode| LIFE
+  PB -->|hook/unhook| NH
+  PB -->|hook/unhook| CT
+  PB -->|hookReplayUI| REPLAY_UI
+  PB -->|hookMainMenu| MENU
+  PB -->|事件总线| RS
+  PB -->|事件总线| CMB
+
+  REC_INST -->|recordGamePacket /<br/>endTick / saveRecording| ARS
+  REC_INST -->|capture| CMB
+  REC_INST -->|exportReplay| EX
+  NH -->|recordGamePacket /<br/>recordSpawnedActor| REC_INST
+  NH -->|chunk 包隔离| RS
+
+  RS -->|init| RR
+  RS -->|handleXxx| REG
+  CT -->|tickPlayback| REC_INST
+  CT -->|tickPlayback| RS
+
+  ARS -->|writer task| RW
+  ARS -->|chunk 缓存| CCP
+  RW -->|action names| REG
+
+  REPLAY_UI -->|tick| ECTRL
+  REPLAY_UI -->|renderer init| D3D
+  REPLAY_UI -->|context| EC
+  ECTRL -->|actions| EC
+  ECTRL -->|setPaused / seek / speed| RS
+  IR -->|swap chain hook| D3D
+  IR -->|snapshot| EC
+  IR -->|drawReplayView| VIEW
+  VIEW -->|EditorAction out| EC
+  RMH -->|replay UI active flag| IR
+  RMH -->|ui 区域| VIEW
+
+  EC -.读.-> RS
+```
+
+## 三种"通信方式"速查
+
+| 方式 | 用在哪里 | 例子 |
+| --- | --- | --- |
+| 显式调用 | 同层或下层模块 | `Recorder::getInstance().recordGamePacket(packet)` |
+| LeviLamina 事件总线 | 跨生命周期阶段、与 LeviLamina 协调 | `ClientStartJoinLevelEvent` → `Playback::hook()` 注册的 lambda |
+| 单例 | 跨模块共享状态 | `ActionRegistry::getInstance()`、`ReplaySession::getInstance()`、`EditorContext gContext` |
+| 原子 / 共享变量 | 跨线程 / 跨 hook | `ReplaySession::mInjectingPacket`（避免回放自己注入的包再被录） |
+
+## 设计原则
+
+1. **Action 协议对称**。录制和回放共用同一套 `Action`（`ActionNextTick` / `ActionLevelChunkCached` / `ActionSubChunkCached` / `ActionGamePacket` / `ActionMoveEntities`），通过 `ActionRegistry` 集中注册，编码用 `ReplayWriter`，解码用 `ReplayReader`。改协议只动一处。
+2. **chunk 数据走旁路**。`FullChunkData` / `SubChunkPacket` 体积大、被 `ReplayReader` 通过 `mChunkPackets` 数组按索引引用，真正字节流压缩后单独存到 `level_chunk_caches/N.bin`，靠 snappy 压缩 + 引用去重。
+3. **录制异步、回放同步**。录制用 `AsyncReplaySaver` 的后台 writer 线程把字节流写到磁盘，避免主线程 stall；回放走 `ReplaySession::tick` 的客户端 tick hook，按时间预算分块注入。
+4. **录制与回放互斥**。`PlaybackMode` 三态：`Unknown` / `Record` / `Replay`；`refreshMode` 根据"是否在回放世界"切换；`Recorder::start` 见到 `isReplayMode()` 直接拒绝。`NetworkHooks` 也靠 `ReplaySession::shouldIsolateChunkPackets()` 在回放模式下抑制原生 chunk 包。
+5. **录制世界是"快照 + 增量"**。每个 ~5 分钟的录制段（`RECORD_CHUNK_TICKS = 20*60*5`）生成一个 `chunk_N.bin`，内含 snapshot（chunk + entity + 玩家列表）和增量 Action 序列；播放时优先复用同一份 snapshot，跳过重复的 `LevelChunk`/`SubChunk`。
+6. **回放世界是隔离的 spectator 世界**。通过 `MinecraftScreenModel::startLocalServerAsync` 起一个 `__playback_replay_world__<uuid>` 的 spectator world，结束后删除。`shouldIsolateChunkPackets`/`isReplayLevel` 是一对判别函数。
+
+## 文件位置速查
+
+| 模块 | 头文件 | 源文件 |
+| --- | --- | --- |
+| 入口 | `src/playback/Playback.h`、`Config.h` | `src/playback/Playback.cpp` |
+| 命令 | `src/playback/command/Command.h` | `command/Command.cpp`、`command/Record.cpp` |
+| Action 协议 | `src/playback/functions/action/Action.h` | `functions/action/Action.cpp`、`ActionRegistry.cpp` |
+| 录制 | `src/playback/functions/record/Recorder.h` | `Recorder.cpp`、`NetworkHooks.cpp`、`ChunkMutationBarrier.cpp`、`ReplayExporter.cpp` |
+| IO | `src/playback/functions/io/AsyncReplaySaver.h` | `AsyncReplaySaver.cpp`、`ReplayReader.cpp`、`ReplayWriter.cpp`、`cache/CachedChunkPacket.h/cpp` |
+| 回放 | `src/playback/functions/replay/ReplaySession.h` | `ReplaySession.cpp` |
+| Tick | `src/playback/functions/tick/ClientTickHooks.h` | `ClientTickHooks.cpp` |
+| 编辑器 | `src/playback/editor/ReplayUI.h` 及子目录 | `editor/ReplayUI.cpp` 及子目录 |
+| 主菜单 | `src/playback/screen/MainMenuHooks.h`、`ReplayBrowser.h` | 同名 `.cpp` |
+| 工具 | `src/playback/utils/PathUtils.h`、`utils/container/LinkedHashMap.h` | `utils/PathUtils.cpp` |
+
+## 下一节
+
+- [record-flow.md](record-flow.md)：录制时序
+- [replay-flow.md](replay-flow.md)：回放时序
+- [editor-flow.md](editor-flow.md)：编辑器时序

--- a/docs/overview/editor-flow.md
+++ b/docs/overview/editor-flow.md
@@ -1,0 +1,169 @@
+# 编辑器时序
+
+## 总览
+
+编辑器由 4 部分组成，本质是一个"游戏画面的 ImGui 浮层"：
+
+| 部分 | 职责 |
+| --- | --- |
+| `EditorContext` | 中央状态机：保存最新 `EditorState`，收集待消费 `EditorAction` |
+| `EditorController` | 每 tick 把 `EditorAction` 翻译成 `ReplaySession` 调用，再把会话状态 publish 成 `EditorState` |
+| `ImGuiRenderer` + `D3D12Hooks` | 钩住 `IDXGISwapChain::Present`，把 `backBuffer` 拷到自己的 `gameTexture`，叠加 ImGui 帧 |
+| `ui::ReplayView`（MenuBar + Timeline） | 渲染时间轴控件，输出 `EditorAction` 给 Context |
+
+## 完整时序图
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant PB as Playback::enable
+    participant D3D as D3D12Hooks
+    participant ReplayUI as editor::ReplayUI<br/>(gContext + gController)
+    participant CT as ClientTickHooks
+    participant ECtrl as EditorController
+    participant EC as EditorContext
+    participant RS as ReplaySession
+    participant Swap as IDXGISwapChain::Present
+    participant IR as ImGuiRenderer<br/>(gImGuiRenderer)
+    participant View as ui::ReplayView<br/>(MenuBar + Timeline)
+    participant U as 用户
+
+    rect rgba(120,180,250,0.18)
+    note over PB,D3D: 1. 装载 (load/enable)
+    PB->>D3D: hookReplayUIRendererInit(true)<br/>(LL_TYPE_INSTANCE_HOOK on RendererContextD3D12::init)
+    D3D-->>ReplayUI: 在 bgfx init 前预先装好 8 个 IDXGI vtable 钩子
+    PB->>ReplayUI: hookReplayUI(true)
+    ReplayUI->>EC: gContext.reset()
+    ReplayUI->>IR: gImGuiRenderer.setContext(&gContext)
+    ReplayUI->>D3D: hookD3D12(true)
+    D3D-->>D3D: installAll: Present/Present1/<br/>ResizeBuffers/ResizeBuffers1/<br/>4 个 CreateSwapChain*
+    ReplayUI->>D3D: hookReplayMouse(true)
+    end
+
+    rect rgba(120,250,160,0.18)
+    note over CT,EC: 2. 每个 client tick 推进状态机
+    loop ClientTickHooks::_subTick
+        CT->>ECtrl: EditorController::tick(hudVisible)
+        ECtrl->>EC: takeActions() (消费用户操作)
+        loop 每个 action
+            ECtrl->>RS: setPaused / requestSeek /<br/>adjustPlaybackSpeed / requestStop
+        end
+        ECtrl->>RS: 读 isActive / isPaused / getPlaybackSpeed /<br/>getCurrentTick / getTotalTicks / hasJoinedReplayWorld
+        ECtrl->>EC: publish(EditorState)
+    end
+
+    CT->>ECtrl: tick(hudVisible) — 顶层 HUD 可见性
+    ECtrl->>EC: publish(hudVisible)
+    end
+
+    rect rgba(250,220,120,0.18)
+    note over Swap,IR: 3. 每帧 Present 钩子
+    Swap->>D3D: presentDetour(swapChain, sync, flags)
+    D3D->>IR: gImGuiRenderer.render(swapChain)
+    IR->>EC: editorContext->snapshot() -> EditorState
+    alt 状态 replayVisible = false 或 hudVisible = false
+        IR-->>D3D: 关闭 mouse input, 必要时 shutdown
+    else 可见
+        IR->>IR: ImGui_ImplDX12_NewFrame
+        IR->>IR: beginReplayMouseFrame(layout)
+        IR->>View: drawReplayView(state, layout, actions)
+        View-->>U: MenuBar / Timeline 控件 (ImGui)
+        U->>U: 点击 / 拖动 timeline / 切档
+        View-->>IR: std::vector<EditorAction> actions
+        IR->>EC: editorContext->submit(action)
+        IR->>IR: endReplayMouseFrame()
+        IR->>IR: ImGui::Render + ImGui_ImplDX12_RenderDrawData
+        IR->>IR: CopyResource(gameTexture <- backBuffer)
+        IR->>IR: ClearRenderTargetView + Draw ImGui
+        IR->>IR: Signal fence (提交到 GPU)
+    end
+    D3D->>Swap: gOriginalPresent(swapChain, ...)
+    D3D->>IR: afterPresent (错误时 shutdown)
+    end
+
+    rect rgba(250,120,160,0.18)
+    note over PB,IR: 4. 卸载
+    PB->>ReplayUI: hookReplayUI(false)
+    ReplayUI->>D3D: hookD3D12(false) -> removeAll
+    D3D->>IR: gImGuiRenderer.shutdown()
+    D3D->>D3D: unbind swap chain queue
+    ReplayUI->>D3D: hookReplayMouse(false)
+    ReplayUI->>D3D: hookReplayUIRendererInit(false)
+    ReplayUI->>IR: gImGuiRenderer.setContext(nullptr)
+    end
+```
+
+## 关键细节
+
+### EditorContext：唯一的可变状态
+
+```cpp
+// snapshot() — 渲染线程用
+// publish(state) — Controller 写
+// submit(action) — Renderer 写
+// takeActions() — Controller 读
+```
+
+互斥锁保护。Renderer 永远只读 `snapshot`，Controller 永远只 `takeActions` + `publish`，避免锁竞争。
+
+### EditorAction 类型
+
+```cpp
+enum class EditorActionType {
+    TogglePause,   Seek,           SkipToStart,
+    SkipToEnd,     DecreaseSpeed,  IncreaseSpeed,
+    StopReplay,
+};
+struct EditorAction { EditorActionType type; int tick; };
+```
+
+`Seek` 才需要 `tick`；其它只看 `type`。
+
+### D3D12 钩子 8 个 vtable
+
+| 钩子 | 作用 |
+| --- | --- |
+| `IDXGISwapChain::Present` | 主渲染入口，每帧拷贝 backBuffer |
+| `IDXGISwapChain1::Present1` | Win8+ Present1，参数有 `DXGI_PRESENT_PARAMETERS` |
+| `IDXGISwapChain::ResizeBuffers` | 释放资源、重新 init |
+| `IDXGISwapChain3::ResizeBuffers1` | 同上但带 `IUnknown* const* presentQueues`；存 queue 给后续使用 |
+| `IDXGIFactory::CreateSwapChain` | 创建时 `bindSwapChainQueue(swapChain, device)` |
+| `IDXGIFactory2::CreateSwapChainForHwnd` | 同上（窗口模式） |
+| `IDXGIFactory2::CreateSwapChainForCoreWindow` | 同上（UWP 模式） |
+| `IDXGIFactory2::CreateSwapChainForComposition` | 同上（合成模式） |
+
+> 注意：`hookReplayUIRendererInit` 是 `LL_TYPE_INSTANCE_HOOK` 钩 `bgfx::d3d12::RendererContextD3D12::init`，保证在 bgfx 真正初始化之前 8 个 vtable 钩子已经装好。这样后面 `CreateSwapChain` 被 bgfx 调用时能直接拿到 queue 句柄。
+
+### ImGuiRenderer 资源
+
+- 私有的 `device` / `commandQueue` / `rtvHeap` / `srvHeap` / `fence` / `fenceEvent`。
+- 每帧：拷 `backBuffer` → `gameTexture`（PIXEL_SHADER_RESOURCE） → `Clear` → `ImGui_ImplDX12_RenderDrawData`。
+- SRV 描述符从自己 32 个槽中分配（`SrvDescriptorCount = 32`）。
+- 字体从 `C:\Windows\Fonts\msyh.ttc` 加载简中常用字符（`GetGlyphRangesChineseSimplifiedCommon`）。
+- `SwapChainReplacementDelay = 500ms`：在 swapChain 替换时（如窗口大小改变）给旧 swapChain 500ms 收尾时间，避免 surface area 缩小时被误判。
+
+### 鼠标钩子
+
+`ReplayMouseHook` 独立于 ImGuiRenderer。当 `setReplayUIActive(true)` 时接管鼠标，ImGui 自己处理；时间轴区域外的事件透传给游戏。`beginReplayMouseFrame(layout, w, h)` 通知钩子"这一帧 UI 区域在哪里"。
+
+### HUD 可见性
+
+`ClientTickHooks::PlaybackClientUpdateHook` 判定 HUD 可见性：
+
+```cpp
+hudVisible = (topScene & SceneType::HudScene) != 0
+          && isInWorldAndNotShowingAnyMenuScreens()
+          && !isShowingLoadingScreen()
+          && !isShowingProgressScreen();
+```
+
+只有同时满足这 4 个条件才显示 ImGui，避免在主菜单、暂停菜单、加载界面打架。
+
+## 编辑器相关模块
+
+- 编辑器总览：[editor/index.md](../editor/index.md)
+- 状态机：[editor/context.md](../editor/context.md)
+- 控制器：[editor/controller.md](../editor/controller.md)
+- 渲染层（D3D12 + ImGui）：[editor/renderer.md](../editor/renderer.md)
+- UI 面板：[editor/ui.md](../editor/ui.md)
+- 入口与生命周期：[playback/lifecycle.md](../playback/lifecycle.md)

--- a/docs/overview/record-flow.md
+++ b/docs/overview/record-flow.md
@@ -1,0 +1,137 @@
+# 录制时序
+
+## 总览
+
+录制路径由 4 个角色组成：
+
+| 角色 | 入口 |
+| --- | --- |
+| 触发方 | `command::Record`（或 `Playback::disable`/`ClientExitLevelEvent` 触发 `Recorder::stop`） |
+| 抓包 | `NetworkHooks`（`PlaybackPacketReceivedHook` / `PlaybackPacketSentHook` / 各专用包 handler） |
+| 汇总 | `Recorder`（状态机 + 序列化 + 玩家 ID 重映射 + 实体状态写盘） |
+| 落盘 | `AsyncReplaySaver` + 后台 writer 线程 + `ReplayWriter` |
+| 导出 | `ReplayExporter`（异步写完后再 zip 压缩到 `data/replays/`） |
+
+`ChunkMutationBarrier` 不在主时序里——它是一个"快照采集时的互斥保护"，保证 Recorder 在抓 snapshot 时不会有并发写 chunk 进来。
+
+## 完整时序图
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as 用户
+    participant Cmd as command/Record
+    participant PB as Playback::getInstance
+    participant Rec as Recorder
+    participant ARS as AsyncReplaySaver<br/>(后台 writer 线程)
+    participant RW as ReplayWriter
+    participant NH as NetworkHooks<br/>(LL_TYPE_INSTANCE_HOOK)
+    participant CMB as ChunkMutationBarrier
+    participant EX as ReplayExporter
+    participant FS as data/replays/*.zip
+
+    rect rgba(120,180,250,0.18)
+    note over U,Cmd: 1. 启动录制
+    U->>Cmd: 输入 "record start"
+    Cmd->>Rec: Recorder::getInstance().start()
+    Rec->>Rec: resetStateForNewRecording()<br/>分配 mAsyncReplaySaver<br/>setup player id remap
+    Rec->>ARS: 构造 (后台线程启动 + writeHeader)
+    ARS->>RW: writeHeader()<br/>写入 magic + action 名表
+    Rec->>NH: hookNetwork(true)
+    Rec->>PB: 拒绝 isReplayMode() (no-op)
+    Rec-->>Cmd: 已启动
+    end
+
+    rect rgba(120,250,160,0.18)
+    note over NH,Rec: 2. tick-by-tick 抓包
+    loop 每个 client tick
+        NH->>Rec: recordGamePacket(packet)
+        Rec->>Rec: 序列化、去重、remap 本地玩家 ID
+        Rec->>Rec: 推入 mPendingGamePackets
+    end
+
+    NH->>Rec: recordSpawnedActor(runtimeId)
+    Rec->>Rec: 写入 AddActor/Equipment/Armor
+    end
+
+    rect rgba(250,220,120,0.18)
+    note over Rec,ARS: 3. endTick(false) — Recorder 自己的 tick 边界
+    Rec->>Rec: mState ∈ {Recording, Closing}?
+    Rec->>Rec: writeInitialSnapshotIfNeeded()
+    alt 首次 tick
+        Rec->>CMB: capture() 等待 2s
+        CMB-->>Rec: CaptureGuard acquired
+        Rec->>Rec: captureChunkSnapshot()<br/>并行序列化所有 Loaded 列<br/>按到玩家距离排序
+        Rec->>ARS: writeSnapshot() 提交<br/>startSnapshot + writeGamePackets + endSnapshot
+        ARS->>ARS: chunk packet 走 mCachedChunkPackets 去重
+        ARS->>RW: writer.startAction(LevelChunkCached/SubChunkCached/...)
+        Rec->>Rec: commitChunkSnapshot()
+    else 后续 tick (每 ~5 分钟轮转)
+        Rec->>CMB: capture()
+        Rec->>Rec: captureChunkSnapshot()
+        Rec->>Rec: writeLocalPlayerState() (属性/装备/护甲/挥砍)
+        Rec->>Rec: flushGamePackets() -> ARS
+        Rec->>Rec: writeEntityMovements() (changed only) -> ARS
+        Rec->>Rec: writeTickBoundary() (ActionNextTick) -> ARS
+        Rec->>ARS: writeReplayChunk(chunkName, meta) 提交<br/>+ 创建 metadata.json(.old 备份)
+    end
+    end
+
+    rect rgba(250,120,160,0.18)
+    note over U,EX: 4. 停止录制并导出
+    U->>Cmd: 输入 "record stop" (或退出世界)
+    Cmd->>Rec: Recorder::stop()
+    Rec->>Rec: mState = Closing
+    Rec->>Rec: endTick(true) (再走一遍第 3 步)
+    Rec->>Rec: logRecordedGamePacketSummary()
+    Rec->>ARS: finish() (mRunning=false + join)
+    ARS->>RW: popBuffer() -> chunk_N.bin
+    Rec->>EX: ReplayExporter::exportReplay(recordDir, outputPath, "")
+    EX->>FS: zip(metadata.json + chunk_*.bin<br/>+ level_chunk_caches/*.bin<br/>+ icon.png)
+    EX-->>Rec: 删除临时 recordDir
+    end
+```
+
+## 关键细节
+
+### 状态机
+
+```
+Idle ──record start──▶ Recording ──record pause──▶ Paused
+                          │   │                       │
+                          │   └──record start──▶ Recording
+                          │   ──record stop──▶ Closing ──endTick+save──▶ Idle
+                          └── ClientExitLevel / disable / fail ──▶ Idle (cancelRecording)
+```
+
+### 玩家 ID 重映射
+
+Recorder 把"当前玩家"映射成"录制世界的固定 ID"（`RecordedPlayerUniqueId` / `RecordedPlayerRuntimeId` / 随机 UUID），在 `recordGamePacket` 里对所有可能引用玩家 ID 的包做 `remapRecordedPlayerReferences`。这样录制存的是"那次会话的稳定 ID"，回放时即使本地玩家不同也不会冲突。
+
+### Tick 边界与 Chunk 轮转
+
+- `RECORD_CHUNK_TICKS = 20 * 60 * 5`：每个 chunk 文件最多覆盖 5 分钟（5 * 60 * 20 = 6000 ticks）。
+- `endTick` 在每个 client tick 末尾跑一次，顺序固定：`writeLocalPlayerState` → `flushGamePackets` → `writeEntityMovements` → `writeTickBoundary`。
+- chunk 轮转时多一步：`captureChunkSnapshot` → `writeLocalPlayerState` → `flushGamePackets` → `writeEntityMovements` → `writeTickBoundary` → `finishCurrentChunk(false)` → `writeSnapshot` → `commitChunkSnapshot`。
+
+### Chunk 快照采集
+
+- `ChunkMutationBarrier::capture()`：等当前 tick 边界完成、阻塞任何新的区块写，最大等待 2s。失败时直接放弃这次轮转。
+- `captureChunkSnapshot()`：遍历 `Dimension::ChunkSource` 中所有 `Loaded` 的列，按"到玩家距离"并行（`std::async`）调用 `SaveContextFactory` 序列化为 `LevelChunkPacket` / `SubChunkPacket`。
+- 实体快照：单独构造 `SetTime` + `PlayerList` + 每个 actor 的 `AddPlayer/AddActor` + 玩家 `MobEquipment`/`MobArmorEquipment`。
+
+### 异步落盘与去重
+
+- 后台线程消费 `mQueue`（`std::function<void(ReplayWriter&)>` 队列）。
+- `FullChunkData` 和 `SubChunkPacket` 走 `mCachedChunkPackets`：长哈希相同的包只在 `level_chunk_caches/<index>.bin` 写一次，`ReplayWriter` 写 `LevelChunkCached/SubChunkCached` Action 时只写一个 `index`。
+- 每 10000 个 chunk packet 滚动一个 snappy 压缩文件。
+- `metadata.json` 用 `.old` 备份再重写，崩溃恢复时不丢。
+- `cancel()` / `~AsyncReplaySaver` 删目录，错误时只设错误状态。
+
+## 录制相关模块
+
+- 协议层：[functions/action.md](../functions/action.md)
+- 录制主循环：[functions/record.md](../functions/record.md)
+- IO 与缓存：[functions/io.md](../functions/io.md)
+- 入口与生命周期：[playback/lifecycle.md](../playback/lifecycle.md)
+- 命令触发：[command/index.md](../command/index.md)

--- a/docs/overview/replay-flow.md
+++ b/docs/overview/replay-flow.md
@@ -1,0 +1,169 @@
+# 回放时序
+
+## 总览
+
+回放路径分两个阶段：
+
+| 阶段 | 入口 | 输出 |
+| --- | --- | --- |
+| 启动 | `screen::ReplayBrowser::openReplay` → `ReplaySession::start(path)` | spectator 隔离世界准备就绪 |
+| 播放 | `ClientTickHooks::_subTick` → `ReplaySession::tick` | 一帧帧把 Action 应用到世界 |
+
+`ReplaySession` 内部状态比 Recorder 复杂：它同时管"本地世界加载"、"快照复用"、"chunk 注入计划"、"speed/seek/pause"。
+
+## 完整时序图
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as 用户
+    participant Menu as MainMenuHooks
+    participant Browser as ReplayBrowser
+    participant PB as Playback
+    participant RS as ReplaySession
+    participant SM as MinecraftScreenModel
+    participant Lev as LeviLamina 事件总线
+    participant Rec as Recorder
+    participant RR as ReplayReader<br/>(一个 chunk 一个)
+    participant REG as ActionRegistry
+    participant Net as NetworkHandler<br/>(LegacyClient)
+    participant CT as ClientTickHooks
+
+    rect rgba(120,180,250,0.18)
+    note over U,Browser: 1. 主菜单选回放
+    U->>Menu: 主菜单点 Playback
+    Menu->>Browser: loadReplays() (扫描 data/replays/*.zip)
+    Browser-->>Menu: ReplaySummary[] (排序后)
+    U->>Menu: 选中 .zip + 双击/点 Open
+    Menu->>Browser: openReplay(replay)
+    Browser->>PB: 校验 replay.canOpen
+    Browser->>RS: ReplaySession::start(path)
+    RS->>RS: init(path) <br/>解 zip, 读 metadata.json<br/>对每个 chunk 构造 ReplayReader
+    RS->>RS: 读 level_chunk_caches/*.bin<br/>(snappy 解压 -> mChunkPackets)
+    RS->>RS: startLocalServerAsync(replayLevelId,<br/>"Playback Replay", spectator + void)
+    SM-->>Lev: 异步起本地服务器
+    Lev-->>PB: ClientStartJoinLevelEvent
+    PB->>RS: onLevelStartJoin() (重置 mScreenModel, 清 network ctx)
+    Lev-->>PB: ClientJoinLevelEvent
+    PB->>RS: onLevelJoined(player)<br/>记录 mReplayPlayer / mReplayDimension
+    PB->>RS: refreshMode(level)<br/>(现在 mode = Replay)
+    Lev-->>PB: ClientCommandRegisterEvent
+    PB->>Recorder: Recorder::start() 被拒绝<br/>(isReplayMode() = true)
+    end
+
+    rect rgba(120,250,160,0.18)
+    note over RS,RR: 2. 初始 snapshot 应用
+    Lev-->>RS: onWorldReady() (内部触发)
+    RS->>RS: applyInitialSnapshot()
+    RS->>RR: reader.handleSnapshot(session)
+    loop snapshot 内每条 Action
+        RR->>REG: action->handle(session, stream)
+        REG->>RS: handleLevelChunkCached / SubChunkCached /<br/>handleGamePacket / handleMoveEntities
+        RS->>RS: 收集到 mPendingLevelChunkIndices 等队列
+    end
+    RS->>RS: prepareChunkInjectionPlan(view)<br/>按到 view 距离排序<br/>标记复用列 / 直接应用列 / 注入列
+    RS->>Net: injectChunkPacket (LevelChunk) — 限速
+    Net-->>RS: onChunkHandleCompleted (NetworkHooks 转发)
+    RS->>RS: mCompletedLevelChunkPositions 累计
+    RS->>Net: injectReadySubChunkPackets (按依赖)
+    RS->>Net: flushPendingSnapshotGamePackets<br/>(PlayerList 先 -> 实体后)
+    RS->>RS: finishChunkInjection() 清理<br/>清空 recorded entities
+    end
+
+    rect rgba(250,220,120,0.18)
+    note over CT,RS: 3. 每个 client tick 推进
+    loop ClientTickHooks::_subTick
+        CT->>RS: ReplaySession::tick()
+        alt seek 目标存在
+            RS->>RS: while mCurrentTick < mSeekTargetTick
+            RS->>RS: advanceReplayTick(false) — 连续快进
+        else 普通播放
+            RS->>RS: mPlaybackTickAccumulator += mPlaybackSpeed
+            loop ticksToAdvance
+                RS->>RS: advanceReplayTick(true)
+                RS->>RR: reader.handleNextAction(session)
+                RR->>REG: action->handle(session, stream)
+                REG->>RS: handleNextTick (mCurrentTick++)<br/>或 handleLevelChunkCached/.../handleMoveEntities
+                RS->>Net: applyGamePacket (via packet->mHandler)
+                end
+            end
+        end
+    end
+
+    CT->>RS: 注入 chunk (如 handleLevelChunkCached 触发)
+    RS->>RS: mChunkInjectionPending = true
+    RS->>RS: 后续 tick 完成 prepareChunkInjectionPlan + 注入
+    end
+
+    rect rgba(250,120,160,0.18)
+    note over U,RS: 4. 退出
+    U->>RS: EditorAction::StopReplay
+    RS->>RS: stop()
+    RS->>RS: requestLeaveGameAsync()
+    Lev-->>PB: ClientExitLevelEvent
+    PB->>RS: onLevelExit() -> ReadyToDelete
+    Lev-->>PB: ClientStartJoinLevelEvent<br/>(重新进主菜单)
+    PB->>RS: onLevelStartJoin() -> finishWorldCleanup
+    PB->>RS: tryFinalizeWorldCleanup (从 worldsPath 删 __playback_replay_world__*)
+    end
+```
+
+## 关键细节
+
+### ReplaySession 内部状态
+
+最关键的几个开关（`mChunkInjectionPending` / `mApplyingChunkSnapshot` / `mSnapshotGamePacketPhase` / `mCenterChunksReady`）控制 chunk 注入流程：
+
+| 状态 | 含义 |
+| --- | --- |
+| `mInitialSnapshotApplied` | 是否已应用过首块 snapshot |
+| `mChunkInjectionPending` | 还有 chunk 等待注入 |
+| `mApplyingChunkSnapshot` | 当前正在应用 snapshot（非增量） |
+| `mSnapshotGamePacketPhase` | `StreamingChunks` / `WaitingAfterPlayerList` / `WaitingAfterEntities` |
+| `mCenterChunksReady` | 中心 5×5 chunk 已就绪 |
+| `mSeekTargetTick` | ≥0 时进入快进模式 |
+| `mIsPaused` / `mPlaybackSpeed` | 用户控制 |
+
+### Chunk 注入计划
+
+`prepareChunkInjectionPlan` 把 snapshot/timeline 的 chunk 分类：
+
+- **复用列 (`mReusableSnapshotColumns`)**：和上一次 snapshot 完全一致且没被破坏（`mDirtySnapshotColumns` 为空），跳过注入。
+- **直接应用列 (`mDirectSnapshotColumns` / `mDirectLevelChunkIndices`)**：维度匹配 + 高度全覆盖 + chunk 已 Loaded，直接 `chunk->deserializeBiomes/deserializeBorderBlocks` 或 `_handleSubChunkData`。
+- **注入列**：通过 `LegacyClientNetworkHandler` 把完整 `LevelChunkPacket`/`SubChunkPacket` 喂给客户端。
+
+中心 5×5 优先（预算 8ms / tick），外圈继续（预算 4ms / tick）。
+
+### 网络包隔离
+
+`NetworkHooks` 中的 `PlaybackLevelChunkHook` / `PlaybackSubChunkHook` / `PlaybackSetTimeHook` 在 `shouldIsolateChunkPackets()` 为 true 时抑制原生包：
+
+- `LevelChunk`：未注入过的列才放行（避免原生抢先把未录制区块填进回放世界）。
+- `SubChunk`：过滤掉已被 snapshot 占用的条目。
+- `SetTime`：在隔离回放世界时直接 drop。
+
+`mInjectingPacket` 原子变量标记"当前是 ReplaySession 自己注入的包"，让 hook 自识别不重入。
+
+### 时间轴控制
+
+- `adjustPlaybackSpeed(direction)`：从 `PlaybackSpeeds = {0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0}` 中按"距离最近"原则取一个。
+- `requestSeek(tick)`：写 `mRequestedSeekTick`，`beginSeek` 找到目标 tick 所在的 chunk（reader），如果回退则重新 apply snapshot，否则只设 `mSeekTargetTick` 让 `tick` 主循环连续快进。
+- `EditorController` 把 UI 的 `EditorAction` 翻译成 `setPaused` / `requestSeek` / `adjustPlaybackSpeed` / `requestStop` / `requestSeek(0/getTotalTicks())`。
+
+### 隔离世界清理
+
+`__playback_replay_world__<uuid>` 命名规则保证回放世界在 `worldsPath` 下可识别。`tryFinalizeWorldCleanup` 在每次 `ClientUpdate` 末尾跑：
+
+- `None` → 扫描 `worldsPath` 找遗留孤立回放世界，标记 `ReadyToDelete`。
+- `WaitingForExit` → 用户已点退出，转 `ReadyToDelete`。
+- `ReadyToDelete` → `cache.deleteLevel(mReplayLevelId)`；等 `REPLAY_WORLD_DELETE_TIMEOUT_TICKS = 20*30` 超时则报错。
+
+## 回放相关模块
+
+- 协议层：[functions/action.md](../functions/action.md)
+- 录制对应的回放数据来源：[functions/io.md](../functions/io.md)（`ReplayReader`）
+- ReplaySession 状态机：[functions/replay.md](../functions/replay.md)
+- Tick 触发与回放/录制分发：[functions/tick.md](../functions/tick.md)
+- 编辑器状态机：[editor/context.md](../editor/context.md)、[editor/controller.md](../editor/controller.md)
+- 主菜单入口：[screen/replay-browser.md](../screen/replay-browser.md)
+- NetworkHooks（隔离世界逻辑）：[functions/record.md](../functions/record.md)

--- a/docs/playback/config.md
+++ b/docs/playback/config.md
@@ -1,0 +1,46 @@
+# Config
+
+`Config` 是 mod 的静态配置，定义在 `src/playback/Config.h`。当前没有从磁盘加载的机制，所有值都是头文件里硬编码的默认值。`Playback::getConfig()` 暴露为常驻引用，可被下游模块读取（如 `command::registerRecordCommand` 读 `command.record.enabled` / `command.record.command`）。
+
+## 字段一览
+
+```cpp
+struct CommandConfigStruct {
+    bool        enabled;
+    std::string command;
+};
+
+struct CommandStruct {
+    CommandConfigStruct record = {true, "record"};
+};
+
+struct Config {
+    int         version    = 1;
+    std::string locateName = "zh_CN";
+
+    CommandStruct command;
+};
+```
+
+| 字段 | 类型 | 默认 | 含义 |
+| --- | --- | --- | --- |
+| `version` | `int` | `1` | 配置 schema 版本。当前未用作迁移入口，留作后续扩展。 |
+| `locateName` | `std::string` | `"zh_CN"` | UI 默认语言键。当前**没有**被代码读取；UI 通过 `resources/texts/languages.json` 决定默认语言。 |
+| `command.record.enabled` | `bool` | `true` | 是否注册 `record` 命令族。`false` 时 `registerRecordCommand` 直接 return。 |
+| `command.record.command` | `std::string` | `"record"` | `record` 命令的命令名，可改成其它（如 `"rec"`）以避免冲突。 |
+
+## 用法
+
+- 读取：`Playback::getInstance().getConfig().command.record`。
+- 修改：当前没有持久化层，构造期改默认值或者在 `Playback::load()` 里读磁盘（待实现）。
+
+## 与 `playback` 之外的关系
+
+- `command/Record.cpp` 读 `command.record.enabled` / `command.record.command`。
+- `i18n` 通过 `Playback::getInstance().getSelf().getLangDir()` 加载 `src/lang/*.json`，与 `Config` 无关。
+- UI 资源包通过 `resources/texts/languages.json` 暴露可用语言列表。
+
+## 扩展点
+
+- 加新命令族：在 `Config` 加 `CommandConfigStruct xxx = {true, "xxx"};` 字段，在 `CommandStruct` 暴露，然后在 `command/*.cpp` 写 `registerXxxCommand(config.command.xxx)`，在 `Playback::setupCommands()` 调用。
+- 改 schema：递增 `version`，并在加载逻辑里做迁移。

--- a/docs/playback/index.md
+++ b/docs/playback/index.md
@@ -1,0 +1,147 @@
+# playback 入口
+
+## 职责
+
+`playback::Playback` 是整个 mod 的入口与生命周期管理器：
+
+- 持有全局 `Config`、事件监听集合、当前 `PlaybackMode`、`LevelId`。
+- 集中注册 Action、注册命令、挂载/卸载 hook。
+- 监听 LeviLamina 的世界生命周期事件（`ClientStartJoinLevelEvent` / `ClientJoinLevelEvent` / `ClientCancelJoinLevelEvent` / `ClientExitLevelEvent` / `ClientCommandRegisterEvent`），把内部模块和外部世界生命周期绑定。
+- 通过 `getInstance()` 暴露为单例；通过 `mSelf` 暴露 `NativeMod`（给日志/i18n/资源目录使用）。
+
+## 文件
+
+| 文件 | 说明 |
+| --- | --- |
+| `src/playback/Playback.h` | 接口（PIMPL 风格） |
+| `src/playback/Playback.cpp` | 实现 + LL_REGISTER_MOD 宏注册 |
+| `src/playback/Config.h` | 全局 `Config` 与 `CommandConfigStruct` |
+
+## 内部结构
+
+```mermaid
+classDiagram
+    class Playback {
+        -Impl impl
+        -NativeMod mSelf
+        +static Playback& getInstance()
+        +Config& getConfig()
+        +set<ListenerPtr>& getEventListeners()
+        +setupCommands()
+        +registerActions()
+        +bool hook()
+        +bool unhook()
+        +bool refreshMode()
+        +void refreshMode(Level&)
+        +PlaybackMode getMode() const
+        +bool isReplayMode() const
+        +bool load()
+        +bool enable()
+        +bool disable()
+    }
+    class Impl {
+        +Config mConfig
+        +set~ListenerPtr~ mEventListeners
+        +atomic~PlaybackMode~ mMode
+        +string mLevelId
+        +bool mRuntimeInstalled
+    }
+    class Config {
+        +int version
+        +string locateName
+        +CommandStruct command
+    }
+    class CommandStruct {
+        +CommandConfigStruct record
+    }
+    class CommandConfigStruct {
+        +bool enabled
+        +string command
+    }
+    Playback o-- Impl
+    Playback ..> Config
+    Config *-- CommandStruct
+    CommandStruct *-- CommandConfigStruct
+```
+
+`Playback::Impl` 是私有嵌套结构（PIMPL），所有可变状态都集中在这里。`mMode` 是 `std::atomic<PlaybackMode>`，允许从网络 hook / tick hook 等无锁读访问。
+
+## 关键数据 / 状态
+
+| 字段 | 含义 |
+| --- | --- |
+| `mConfig` | 启动时构造一次（默认值在 `Config.h`） |
+| `mEventListeners` | 生命周期内订阅的 LeviLamina 事件监听器，unhook 时一并清空 |
+| `mMode` | `Unknown` / `Record` / `Replay` 三态。`refreshMode` 写入 |
+| `mLevelId` | 当前 world 的 level id，跨世界切换时清空 |
+| `mRuntimeInstalled` | `hook()` 成功装上的所有运行时 hook 是否还在 |
+
+`PlaybackMode` 三态决定了 `ClientTickHooks::tickPlayback()` 走 `Recorder::endTick(false)` 还是 `ReplaySession::tick()`：
+
+```cpp
+switch (playback::Playback::getInstance().getMode()) {
+    case playback::PlaybackMode::Record:
+        Recorder::getInstance().endTick(false);
+        break;
+    case playback::PlaybackMode::Replay:
+        ReplaySession::getInstance().tick();
+        break;
+    case playback::PlaybackMode::Unknown:
+    default:
+        break;
+}
+```
+
+## 关键方法
+
+- `getInstance()`：Meyers singleton，进程内唯一。
+- `getConfig()` / `getEventListeners()`：对 `Impl` 字段的只读/读写访问。
+- `setupCommands()`：在 `ClientCommandRegisterEvent` 中调用，向 LeviLamina 的客户端命令注册器注册 `playback` 和 `record` 命令族。
+- `registerActions()`：在 `load()` 时调用一次，向 `ActionRegistry::getInstance()` 注册 5 个 Action。
+- `hook()` / `unhook()`：批量装/卸运行时 hook（`hookNetwork` / `hookClientTick` / `hookMainMenu` / `hookReplayUI`），有原子回滚逻辑。
+- `refreshMode()` / `refreshMode(Level&)`：根据当前 world 是不是回放世界，决定 `mMode`。`isReplayLevel(Level const&)` 由 `ReplaySession` 提供。
+- `isReplayMode()`：`mMode == PlaybackMode::Replay`，主要给 `Recorder::start()` 做拦截。
+- `load()` / `enable()` / `disable()`：LeviLamina 框架要求的 3 个生命周期钩子。
+
+## 模块关系
+
+### 被谁调用
+
+- `LL_REGISTER_MOD(playback::Playback, playback::Playback::getInstance())`：LeviLamina 框架启动时调用 `load()` / `enable()`，关闭时 `disable()`。
+- `command::Record.cpp`（间接）：通过 `Playback::getInstance().getSelf().getLogger()` 取 logger。
+- `Recorder` / `ReplaySession` / `EditorController` / `MainMenuHooks` / `NetworkHooks` 等：都通过 `Playback::getInstance().getSelf().getLogger()` 或 `getMode()` / `isReplayMode()` 引用入口。
+
+### 调用谁
+
+| 动作 | 调用的模块 |
+| --- | --- |
+| `registerActions()` | `functions::ActionRegistry::getInstance()` |
+| `setupCommands()` | `command::registerPlaybackCommand` / `registerRecordCommand` |
+| `hook()` / `unhook()` | `screen::hookMainMenu` / `functions::hookNetwork` / `functions::hookClientTick` / `editor::hookReplayUI` |
+| `load()` | `editor::hookReplayUIRendererInit`（在 D3D12 renderer 初始化前装好钩子） |
+| 事件回调 | `ReplaySession::onLevelStartJoin/Joined/Exit/JoinCancelled` / `ChunkMutationBarrier::setActiveLevel` / `Recorder::stop` |
+| `refreshMode()` | `ReplaySession::isReplayLevel` |
+
+### 共享数据
+
+- 全局 `Config`：在 `Config.h` 中以默认值声明，运行时不变（当前实现里没暴露写）。
+- `Playback::getInstance().getSelf().getSelf().getLangDir()`：被 `load()` 用于 i18n。
+- `Playback::getInstance().getSelf().getDataDir()`：被 `utils::PathUtils::getInstance()` 用作 `mDataDir` 根。
+
+### 事件订阅
+
+`hook()` 中向 `ll::event::EventBus::getInstance()` 订阅：
+
+| 事件 | 用途 |
+| --- | --- |
+| `ClientCommandRegisterEvent` | 调 `setupCommands()` |
+| `ClientStartJoinLevelEvent` | `ReplaySession::onLevelStartJoin` + `ChunkMutationBarrier::setActiveLevel(nullptr)` + 清 `mLevelId` / 重置 `mMode` |
+| `ClientCancelJoinLevelEvent` | `ReplaySession::onLevelJoinCancelled` |
+| `ClientJoinLevelEvent` | `ChunkMutationBarrier::setActiveLevel(...)` + `ReplaySession::onLevelJoined` + `refreshMode` |
+| `ClientExitLevelEvent` | `ReplaySession::onLevelExit` + 必要时 `Recorder::stop` + `ChunkMutationBarrier::setActiveLevel(nullptr)` |
+
+## 扩展点
+
+- 新增 Action：在 `functions/action/Action.h` 加一个 `struct XxxAction : Action` 单例（命名 `XxxAction::getInstance()`），然后在 `Playback::registerActions()` 里 `registry.registerAction(std::make_unique<...>())`。
+- 新增命令族：写一个 `command::registerXxxCommand` 函数，在 `Playback::setupCommands()` 里调。
+- 新增世界级 hook：先写一个 `bool hookXxx(bool)`（与 `hookNetwork` 同风格），然后在 `Playback::hook()` / `unhook()` 中维护，并加进对应的事件回调。

--- a/docs/playback/lifecycle.md
+++ b/docs/playback/lifecycle.md
@@ -1,0 +1,101 @@
+# 生命周期
+
+Playback 在 LeviLamina 框架下走 `load` → `enable` → (`disable` / `unload`) 三段式。运行时还通过 `hook` / `unhook` 维护一组可重入的运行时钩子（network / tick / main menu / replay UI）。
+
+## 顶层时序
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant FW as LeviLamina 框架
+    participant PB as Playback
+    participant D3D as editor::D3D12Hooks
+    participant NH as functions::NetworkHooks
+    participant CT as functions::ClientTickHooks
+    participant UI as editor::ReplayUI
+    participant MM as screen::MainMenuHooks
+    participant RS as functions::ReplaySession
+    participant Rec as functions::Recorder
+
+    rect rgba(120,180,250,0.18)
+    note over FW,Rec: 加载阶段
+    FW->>PB: load()
+    PB->>PB: configurationLog() (DEBUG 下提日志级别)
+    PB->>PB: ll::i18n::getInstance().load(langDir)
+    PB->>PB: registerActions()
+    PB->>D3D: hookReplayUIRendererInit(true)<br/>(LL_TYPE_INSTANCE_HOOK on bgfx::d3d12::RendererContextD3D12::init)
+    PB->>PB: hook()<br/>装 network + tick + main menu
+    PB->>MM: hookMainMenu(true)
+    PB->>NH: hookNetwork(true)
+    PB->>CT: hookClientTick(true)
+    PB->>PB: 订阅 5 个 ClientXxxLevel 事件
+    end
+
+    rect rgba(120,250,160,0.18)
+    note over FW,UI: 启用阶段
+    FW->>PB: enable()
+    PB->>PB: hook() (再次幂等安装)
+    PB->>UI: hookReplayUI(true)
+    UI->>D3D: hookD3D12(true) (8 个 DXGI vtable)
+    UI->>UI: hookReplayMouse(true)
+    end
+
+    rect rgba(250,220,120,0.18)
+    note over FW,Rec: 运行中事件流
+    FW-->>PB: ClientStartJoinLevelEvent
+    PB->>RS: onLevelStartJoin
+    PB->>RS: 改 mMode = Unknown
+
+    FW-->>PB: ClientJoinLevelEvent
+    PB->>RS: onLevelJoined
+    PB->>PB: refreshMode(level) -> Record or Replay
+    end
+
+    rect rgba(250,120,160,0.18)
+    note over FW,Rec: 卸载
+    FW->>PB: disable()
+    PB->>RS: 拒绝（如果还在回放世界 / 清理中）
+    PB->>Rec: Recorder::stop()
+    PB->>PB: unhook()
+    PB->>CT: hookClientTick(false)
+    PB->>NH: hookNetwork(false)
+    PB->>UI: hookReplayUI(false)
+    PB->>MM: hookMainMenu(false)
+    PB->>PB: 清事件监听 + mMode = Unknown
+    end
+```
+
+## hook / unhook 状态机
+
+`Playback::Impl::mRuntimeInstalled` 标记一组运行时 hook 是否全部到位。
+
+`hook()` 顺序（`enable` + `load` 路径都用到）：
+
+1. `screen::hookMainMenu(true)` — 主菜单 UI 钩子
+2. `functions::hookNetwork(true)` — 网络包抓取 + 回放包隔离
+3. `functions::hookClientTick(true)` — tick 边界与每 tick 调度
+4. 订阅 5 个事件
+
+`unhook()` 顺序与 `hook()` 相反：
+
+1. `functions::hookClientTick(false)` — 先解 tick
+2. `functions::hookNetwork(false)` — 再解 network
+3. `editor::hookReplayUI(false)` — 再解 UI
+4. `screen::hookMainMenu(false)` — 最后解主菜单
+5. 清 `mEventListeners`，重置 `mMode`
+
+任意一步失败都会触发回滚（再次装回 + 日志），保证状态不破碎。
+
+## 关键不变量
+
+- `mMode` 只能由 `refreshMode` 写入；`ClientStartJoinLevelEvent` 把它设回 `Unknown`；`ClientExitLevelEvent` 也设回 `Unknown`。
+- `hook()` 幂等：`mRuntimeInstalled` 已为 true 时直接 return true。
+- `Recorder::start` 在 `isReplayMode()` 为 true 时拒绝。`NetworkHooks` 在回放模式下抑制原生 chunk 包。两条防线共同保证"录制与回放互斥"。
+- `disable()` 在 `ReplaySession::isIsolatingReplayWorld() || isReplayWorldCleanupPending()` 时直接拒绝，要求用户先退出回放世界。
+
+## 与其它模块的关系
+
+- `hook()` 装的是"运行时所有 hook 的并集"，由 `Playback` 集中调度。
+- `hookReplayUIRendererInit` 单独由 `Playback::load()` 调用，因为它必须在 `bgfx::d3d12::RendererContextD3D12::init` 之前装好（通过 `LL_TYPE_INSTANCE_HOOK` 钩在 init 头部）。
+- `hookReplayUI` 在 `Playback::enable()` 调用，因为 `load()` 时创建 DXGI factory 会触发 loader lock。
+- 5 个事件订阅：见 [playback/index.md](index.md) 的"事件订阅"一节。


### PR DESCRIPTION
新增了完整的项目文档体系，包括：
- 总览文档与分层架构图
- 录制/回放/编辑器完整时序图
- 各模块详细设计与实现说明
- 命令、配置、生命周期完整说明

## Summary

Describe the problem and the focused change that resolves it.

## Validation

- [ ] `xmake -r -y`
- [ ] `git diff --check`
- [ ] Tested in Minecraft when the change affects recording, replay, or UI behavior

Describe any additional validation and list the Minecraft, LeviLamina, and Playback versions used.

## Compatibility and Replay Impact

Describe changes to compatibility, replay files, recorded data, or runtime behavior. Write `None` when not applicable.

## Checklist

- [ ] The change is focused and contains no unrelated refactoring.
- [ ] Changed C++ files have been formatted with the repository configuration.
- [ ] Translation keys remain aligned across supported languages where applicable.
- [ ] New third-party code or assets include the required license notice.
- [ ] Logs, replays, screenshots, and test data contain no private server or player information.
