### PR TITLE
fix: fix mouse coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1-mc26.20] - 2026-07-29
+
+### Changed
+
+- Adapted to Minecraft 26.20.4
+
 ## [0.1.0-alpha.2] - 2026-07-29
 
 ### Changed
@@ -12,9 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bundled the Playback UI resource pack with the mod so LeviLauncher and Lip installations load it automatically through LeviLamina.
 - Kept `playback-ui.mcpack` available as a standalone release asset for manual import.
 
-### Notes
-
-- This release changes installation packaging only. The replay format and replay runtime behavior are unchanged from `0.1.0-alpha.1`.
+  > **This release changes installation packaging only. The replay format and replay runtime behavior are unchanged from `0.1.0-alpha.1`.**
 
 ## [0.1.0-alpha.1] - 2026-07-27
 
@@ -26,10 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chunk snapshots, cached chunk replay, entity movement, and selected game-packet replay.
 - English and Simplified Chinese localization for commands, the replay editor, and the resource-pack UI.
 
-### Notes
+  > **This is the first public test release. Replay files and behavior may change before `1.0.0`.**
+  > **Playback currently targets Windows x64 and the LeviLamina `26.10.*` client runtime.**
 
-- This is the first public test release. Replay files and behavior may change before `1.0.0`.
-- Playback currently targets Windows x64 and the LeviLamina `26.10.*` client runtime.
-
-[0.1.0-alpha.2]: https://github.com/wo55555/Playback/compare/v0.1.0-alpha.1...v0.1.0-alpha.2
-[0.1.0-alpha.1]: https://github.com/wo55555/Playback/releases/tag/v0.1.0-alpha.1
+[0.1.1-mc26.20]: https://github.com/ShrBox/Playback/compare/v0.1.0-alpha.2...v0.1.1-mc26.20
+[0.1.0-alpha.2]: https://github.com/ShrBox/Playback/compare/v0.1.0-alpha.1...v0.1.0-alpha.2
+[0.1.0-alpha.1]: https://github.com/ShrBox/Playback/releases/tag/v0.1.0-alpha.1

--- a/src/playback/editor/renderer/ReplayMouseHook.cpp
+++ b/src/playback/editor/renderer/ReplayMouseHook.cpp
@@ -157,9 +157,15 @@ void handleMouseInput(ll::event::MouseInputEvent& event) {
     ActiveMouseCallback activeCallback;
     if (!replayUiOwnsMouse()) return;
 
-    char const  action = event.actionButtonId();
-    float const x      = static_cast<float>(event.x()) * gInputScaleX.load(std::memory_order_relaxed);
-    float const y      = static_cast<float>(event.y()) * gInputScaleY.load(std::memory_order_relaxed);
+    char const action = event.actionButtonId();
+    // The X and Y coordinates in the event are broken in 26.20.4, so we need to get the cursor position by WINAPI.
+    POINT cursor{};
+    HWND  window = GetActiveWindow();
+    if (!GetCursorPos(&cursor) || !ScreenToClient(window, &cursor)) {
+        return;
+    }
+    float const x      = static_cast<float>(cursor.x) * gInputScaleX.load(std::memory_order_relaxed);
+    float const y      = static_cast<float>(cursor.y) * gInputScaleY.load(std::memory_order_relaxed);
     bool const  inGame = isGameViewportPoint(x, y);
     bool const  popup  = gPopupOpen.load(std::memory_order_acquire);
     auto const  owner  = gMouseOwner.load(std::memory_order_acquire);

--- a/tooth.json
+++ b/tooth.json
@@ -2,7 +2,7 @@
   "format_version": 3,
   "format_uuid": "289f771f-2c9a-4d73-9f3f-8492495a924d",
   "tooth": "github.com/wo55555/Playback",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.1-mc26.20",
   "info": {
     "name": "Playback",
     "description": "Record, export, and replay Minecraft Bedrock client sessions.",


### PR DESCRIPTION
## Summary

Fixed mouse coordinates error caused by MouseInputEvent

## Validation

- [x] `xmake -r -y`
- [x] `git diff --check`
- [x] Tested in Minecraft when the change affects recording, replay, or UI behavior

Describe any additional validation and list the Minecraft, LeviLamina, and Playback versions used.

## Compatibility and Replay Impact

None

## Checklist

- [x] The change is focused and contains no unrelated refactoring.
- [x] Changed C++ files have been formatted with the repository configuration.
- [x] Translation keys remain aligned across supported languages where applicable.
- [x] New third-party code or assets include the required license notice.
- [x] Logs, replays, screenshots, and test data contain no private server or player information.
