### PR TITLE
chore: generate pdb by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,8 +94,6 @@ jobs:
 
       - run: |
           mv artifact/playback-ui.mcpack playback-ui.mcpack
-          rm -f artifact/playback/*.pdb artifact/playback/playback-ui.zip
-          rm -rf artifact/playback/data
           cp CHANGELOG.md LICENSE README.md README_ZH.md artifact/
 
       - run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1-mc26.10] - 2026-07-29
+
+### Changed
+
+- Add .pdb to help diagnosis crashes.
+
 ## [0.1.0-alpha.2] - 2026-07-29
 
 ### Changed
@@ -12,9 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bundled the Playback UI resource pack with the mod so LeviLauncher and Lip installations load it automatically through LeviLamina.
 - Kept `playback-ui.mcpack` available as a standalone release asset for manual import.
 
-### Notes
-
-- This release changes installation packaging only. The replay format and replay runtime behavior are unchanged from `0.1.0-alpha.1`.
+  > **This release changes installation packaging only. The replay format and replay runtime behavior are unchanged from `0.1.0-alpha.1`.**
 
 ## [0.1.0-alpha.1] - 2026-07-27
 
@@ -26,10 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chunk snapshots, cached chunk replay, entity movement, and selected game-packet replay.
 - English and Simplified Chinese localization for commands, the replay editor, and the resource-pack UI.
 
-### Notes
+  > **This is the first public test release. Replay files and behavior may change before `1.0.0`.**
+  > **Playback currently targets Windows x64 and the LeviLamina `26.10.*` client runtime.**
 
-- This is the first public test release. Replay files and behavior may change before `1.0.0`.
-- Playback currently targets Windows x64 and the LeviLamina `26.10.*` client runtime.
-
-[0.1.0-alpha.2]: https://github.com/wo55555/Playback/compare/v0.1.0-alpha.1...v0.1.0-alpha.2
-[0.1.0-alpha.1]: https://github.com/wo55555/Playback/releases/tag/v0.1.0-alpha.1
+[0.1.1-mc26.10]: https://github.com/ShrBox/Playback/compare/v0.1.0-alpha.2...v0.1.1-mc26.10
+[0.1.0-alpha.2]: https://github.com/ShrBox/Playback/compare/v0.1.0-alpha.1...v0.1.0-alpha.2
+[0.1.0-alpha.1]: https://github.com/ShrBox/Playback/releases/tag/v0.1.0-alpha.1

--- a/tooth.json
+++ b/tooth.json
@@ -2,7 +2,7 @@
   "format_version": 3,
   "format_uuid": "289f771f-2c9a-4d73-9f3f-8492495a924d",
   "tooth": "github.com/wo55555/Playback",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.1-mc26.10",
   "info": {
     "name": "Playback",
     "description": "Record, export, and replay Minecraft Bedrock client sessions.",

--- a/xmake.lua
+++ b/xmake.lua
@@ -22,9 +22,21 @@ if not has_config("vs_runtime") then
     set_runtimes("MD")
 end
 
+local get_version = function(os)
+    local tag = os.iorun("git describe --tags --abbrev=0 --always")
+    local major, minor, patch, suffix = tag:match("v(%d+)%.(%d+)%.(%d+)(.*)")
+    if not major then
+        print("Failed to parse version tag, using 0.0.0")
+        major, minor, patch = 0, 0, 0
+    end
+    if suffix and suffix ~= "" then
+        return major .. "." .. minor .. "." .. patch .. string.gsub(suffix, "%s+$", "")
+    end
+    return major .. "." .. minor .. "." .. patch
+end
+
 target("playback")
     add_rules("@levibuildscript/linkrule")
-    add_rules("@levibuildscript/modpacker", {modVersion = "0.1.0-alpha.2"})
     add_cxflags( "/EHa", "/utf-8", "/W4", "/w44265", "/w44289", "/w44296", "/w45263", "/w44738", "/w45204")
     add_defines("NOMINMAX", "UNICODE")
     add_packages("levilamina")
@@ -44,7 +56,12 @@ target("playback")
     add_files("src/**.cpp")
     add_includedirs("src")
     set_symbols("debug")
-    after_build(function(target)
+    on_load(function (target)
+        target:add("rules", "@levibuildscript/modpacker", {
+            modVersion = get_version(os),
+        })
+    end)
+    after_build(function (target)
         import("utils.archive")
 
         local output_dir = path.join(os.projectdir(), "bin", target:name())

--- a/xmake.lua
+++ b/xmake.lua
@@ -43,21 +43,19 @@ target("playback")
     add_headerfiles("src/**.h")
     add_files("src/**.cpp")
     add_includedirs("src")
+    set_symbols("debug")
     after_build(function(target)
         import("utils.archive")
 
         local output_dir = path.join(os.projectdir(), "bin", target:name())
         os.mkdir(output_dir)
-        os.cp(path.join(os.projectdir(), "LICENSE"), path.join(output_dir, "LICENSE"))
-        os.cp(
-            path.join(os.projectdir(), "THIRD_PARTY_NOTICES.md"),
-            path.join(output_dir, "THIRD_PARTY_NOTICES.md")
-        )
+        os.cp(path.join(os.projectdir(), "LICENSE"), output_dir)
+        os.cp(path.join(os.projectdir(), "THIRD_PARTY_NOTICES.md"), output_dir)
 
-        local license_source = path.join(os.projectdir(), "licenses", "DearImGui-LICENSE.txt")
+        local license_source = path.join(os.projectdir(), "licenses")
         local license_dir = path.join(output_dir, "licenses")
-        os.mkdir(license_dir)
-        os.cp(license_source, path.join(license_dir, "DearImGui-LICENSE.txt"))
+        os.tryrm(license_dir)
+        os.cp(license_source, license_dir)
 
         local lang_source = path.join(os.projectdir(), "src", "lang")
         local lang_dir = path.join(output_dir, "lang")
@@ -72,7 +70,6 @@ target("playback")
             assert(os.isfile(path.join(resource_dir, "manifest.json")), "resource pack manifest.json was not found")
             os.tryrm(installed_pack)
             os.cp(resource_dir, installed_pack)
-            os.tryrm(path.join(output_dir, target:name() .. "-ui.mcpack"))
             os.tryrm(mcpack)
             os.tryrm(mcpack_zip)
             archive.archive(mcpack_zip, "*", {
@@ -80,7 +77,6 @@ target("playback")
                 recurse = true
             })
             os.mv(mcpack_zip, mcpack)
-            os.tryrm(mcpack_zip)
             cprint("${bright green}[Playback]: ${reset}UI resource pack installed to " .. installed_pack)
             cprint("${bright green}[Playback]: ${reset}Standalone UI resource pack generated to " .. mcpack)
         end


### PR DESCRIPTION
## Summary

chore: automatically fill version in xmake.lua
chore: prepare CHANGELOG for v0.1.1-mc26.10

## Validation

- [x] `xmake -r -y`
- [x] `git diff --check`
- [x] Tested in Minecraft when the change affects recording, replay, or UI behavior

Describe any additional validation and list the Minecraft, LeviLamina, and Playback versions used.

## Compatibility and Replay Impact

None

## Checklist

- [x] The change is focused and contains no unrelated refactoring.
- [x] Changed C++ files have been formatted with the repository configuration.
- [x] Translation keys remain aligned across supported languages where applicable.
- [x] New third-party code or assets include the required license notice.
- [x] Logs, replays, screenshots, and test data contain no private server or player information.
