### PR TITLE
Enhance Dependabot configuration in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,41 @@
 version: 2
+
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
+
     schedule:
-      interval: weekly
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "Etc/GMT"
+
+    open-pull-requests-limit: 10
+
+    labels:
+      - "github_actions"
+      - "dependencies"
+
+    pull-request-branch-name:
+      separator: "/"
+
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+    groups:
+      github-official:
+        patterns:
+          - "actions/*"
+        update-types:
+          - "minor"
+          - "patch"
+
+      third-party-actions:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "actions/*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
# ci: standardize Dependabot GitHub Actions updates

This PR improves the repository's Dependabot configuration to make GitHub Actions dependency updates more predictable, organized, and easier to review.

## Files changed

### Dependency Management

* [x] `.github/dependabot.yml`

  * Replaced Dependabot's flexible weekly scheduling with a fixed **Monday schedule**, making dependency checks predictable and easier to anticipate.
  * Defined an explicit **time and timezone** instead of allowing Dependabot to select a variable time within the weekly interval.
  * Set a limit of **10 open dependency update pull requests** to prevent update backlogs from becoming unnecessarily large.
  * Added standardized `github_actions` and `dependencies` labels so automated dependency PRs can be identified and filtered consistently.
  * Standardized Dependabot commit messages with the `ci` prefix and dependency scope, keeping generated commits aligned with the repository's CI/conventional-commit structure.
  * Configured a consistent `/` separator for Dependabot pull-request branch names.
  * Grouped **minor and patch updates** so compatible, low-risk updates can be reviewed together instead of producing a separate PR for every individual action.
  * Separated **official GitHub Actions** from **third-party actions** into different update groups, making the source and scope of automated changes clearer during review.
  * Kept **major updates outside these groups**, ensuring potentially breaking version changes receive individual review rather than being bundled with routine updates.

## Benefits

* **Predictable maintenance:** dependency checks happen at a known time each week instead of at an arbitrary point during the weekly interval.
* **Cleaner pull requests:** related minor and patch updates are consolidated, reducing unnecessary PR noise.
* **Safer major updates:** major-version changes remain individually reviewable because they may contain breaking changes.
* **Clearer ownership and review:** official GitHub-maintained actions and third-party actions are separated, making it easier to assess update risk.
* **Consistent automation:** labels, branch names, and commit messages follow a defined convention instead of relying entirely on Dependabot's generic defaults.
* **Lower maintenance overhead:** fewer routine dependency PRs means less repetitive CI review while still keeping Actions dependencies current.

> [!IMPORTANT]
> This is a CI/dependency-management configuration change. It does not modify application source code, build logic, or runtime behavior.