### PR TITLE
fix(editor): render the overlay from the BGFX submit path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the replay editor overlay never appearing while another overlay that detours DXGI `Present`, such as RivaTuner Statistics Server, is attached to the client. The overlay is now composited from the BGFX D3D12 submit path, which the replay browser reaches even when the present detour is bypassed.
+- Fixed the overlay losing its swap-chain resources after a window resize that the `ResizeBuffers` detour did not observe.
+
 ## [0.2.0-mc26.10] - 2026-08-20
 
 ### Added

--- a/src/playback/editor/graphics/D3D12Hooks.cpp
+++ b/src/playback/editor/graphics/D3D12Hooks.cpp
@@ -94,6 +94,7 @@ std::unordered_map<ID3D12Device*, DeviceQueueCandidate> gDeviceQueueMap;
 std::atomic<bool> gTimelineHooksStopping{true};
 std::atomic<bool> gRendererInitHookStopping{true};
 std::atomic<bool> gD3D12RendererActive{false};
+std::atomic<bool> gOverlayRenderedInSubmit{false};
 
 std::atomic<uint32_t>   gActiveDetours{};
 std::mutex              gActiveDetoursMutex;
@@ -187,7 +188,8 @@ bool noneInstalled(HookState const& state) {
 DECLARE_DETOUR_FN(present, HRESULT, IDXGISwapChain* swapChain, UINT syncInterval, UINT flags) {
     ActiveDetour activeDetour;
     bool const   offlineRender = exporting::isOfflineRenderActivityActive();
-    if ((flags & DXGI_PRESENT_TEST) == 0 && !gTimelineHooksStopping.load(std::memory_order_acquire)) {
+    if ((flags & DXGI_PRESENT_TEST) == 0 && !gTimelineHooksStopping.load(std::memory_order_acquire)
+        && !gOverlayRenderedInSubmit.exchange(false, std::memory_order_acq_rel)) {
         (void)renderPresentFrame(swapChain);
     }
     bool const    offlinePresent        = offlineRender && gImGuiRenderer.ownsSwapChain(swapChain);
@@ -210,7 +212,8 @@ DECLARE_DETOUR_FN(
     bool         timelineRendered{};
     bool const   offlineRender = exporting::isOfflineRenderActivityActive();
     if ((flags & DXGI_PRESENT_TEST) == 0 && !gTimelineHooksStopping.load(std::memory_order_acquire)) {
-        timelineRendered = renderPresentFrame(baseSwapChain);
+        timelineRendered = gOverlayRenderedInSubmit.exchange(false, std::memory_order_acq_rel)
+                        || renderPresentFrame(baseSwapChain);
     }
 
     DXGI_PRESENT_PARAMETERS fullSurfacePresent{};
@@ -614,6 +617,17 @@ LL_TYPE_INSTANCE_HOOK(
             ? exporting::claimOfflineRenderBoundary(render, frameNumber)
             : std::nullopt;
     origin(render, clearQuad, textVideoMemBlitter);
+
+    // Third-party overlays such as RTSS detour DXGI Present and can bypass the present detour entirely.
+    // BGFX has not flipped the back buffer yet, so compositing here still reaches the presented frame.
+    if (!exporting::isOfflineRenderActivityActive() && !gTimelineHooksStopping.load(std::memory_order_acquire)) {
+        if (auto* const presentTarget = this->m_swapChain) {
+            gImGuiRenderer.syncSwapChainGeometry(presentTarget);
+            if (gImGuiRenderer.render(presentTarget, false)) {
+                gOverlayRenderedInSubmit.store(true, std::memory_order_release);
+            }
+        }
+    }
 
     if (!ticket) return;
 

--- a/src/playback/editor/graphics/ImGuiRenderer.cpp
+++ b/src/playback/editor/graphics/ImGuiRenderer.cpp
@@ -1239,6 +1239,17 @@ bool ImGuiRenderer::beforeResize(IDXGISwapChain* sc) {
     return true;
 }
 
+bool ImGuiRenderer::syncSwapChainGeometry(IDXGISwapChain* sc) {
+    std::scoped_lock lk(mImpl->mutex);
+    if (!sc || !mImpl->initialized || sc != mImpl->swapChain) return false;
+    auto const area = getSwapChainArea(sc);
+    if (area == 0 || area == mImpl->surfaceArea) return false;
+    mImpl->shutdown(visuals::FrameTapError::Resize, "Swap chain resized during frame capture");
+    mImpl->initFailed      = false;
+    mImpl->lastInitAttempt = {};
+    return true;
+}
+
 void ImGuiRenderer::afterPresent(IDXGISwapChain* sc, long result) {
     if (result != DXGI_ERROR_DEVICE_REMOVED && result != DXGI_ERROR_DEVICE_RESET) return;
     std::scoped_lock lk(mImpl->mutex);

--- a/src/playback/editor/graphics/ImGuiRenderer.h
+++ b/src/playback/editor/graphics/ImGuiRenderer.h
@@ -42,6 +42,7 @@ public:
     [[nodiscard]] bool isD3D12RendererActive() const;
     [[nodiscard]] bool ownsSwapChain(IDXGISwapChain* swapChain) const;
     bool               beforeResize(IDXGISwapChain* swapChain);
+    bool               syncSwapChainGeometry(IDXGISwapChain* swapChain);
     void               afterPresent(IDXGISwapChain* swapChain, long result);
     bool               shutdown();
 


### PR DESCRIPTION
Overlays that detour IDXGISwapChain::Present, such as RivaTuner Statistics Server, can bypass the replay timeline's own present detour. When that happened the replay browser opened logically but never drew: the button handler ran and menu input was suspended, yet renderInternal was never reached, so not even its warnings were logged.

Composite the overlay at the end of the RendererContextD3D12::submit hook instead. That hook is on the client's own renderer, so it cannot be detoured away, and BGFX has not flipped the back buffer yet. The present detours keep their existing path and skip the frame when the submit path already drew it, so machines without a competing overlay render exactly once. Offline export is left on its current route.

Because a competing overlay also swallows ResizeBuffers, add syncSwapChainGeometry() so the overlay rebuilds its swap-chain resources when the back buffer changes size without beforeResize() being called.

Validated on Minecraft Bedrock 1.26.10.04 with LeviLamina 26.10.14, with RivaTuner Statistics Server 7.x and MSI Afterburner attached: the replay browser now renders, with the RTSS OSD composited above it.

## Summary

Describe the problem and the focused change that resolves it.

## Validation

- [ ] `xmake -r -y`
- [ ] `git diff --check`
- [ ] Tested in Minecraft when the change affects recording, replay, or UI behavior

Describe any additional validation and list the Minecraft, LeviLamina, and Playback versions used.

## Compatibility and Replay Impact

Describe changes to compatibility, replay files, recorded data, or runtime behavior. Write `None` when not applicable.

## Checklist

- [ ] The change is focused and contains no unrelated refactoring.
- [ ] Changed C++ files have been formatted with the repository configuration.
- [ ] Translation keys remain aligned across supported languages where applicable.
- [ ] New third-party code or assets include the required license notice.
- [ ] Logs, replays, screenshots, and test data contain no private server or player information.
