### PR TITLE
Optimize performance of array checks and chunk lookups

### DIFF
--- a/src/playback/editor/graphics/CameraRenderHooks.cpp
+++ b/src/playback/editor/graphics/CameraRenderHooks.cpp
@@ -218,9 +218,18 @@ void writeCameraSpaces(
     size_t                      appliedCount{};
     for (auto* camera : localCameras) {
         if (!camera || camera == &worldCamera) continue;
-        if (std::find(applied.begin(), applied.begin() + appliedCount, camera) != applied.begin() + appliedCount) {
+
+        bool isApplied = false;
+        for (size_t i = 0; i < appliedCount; ++i) {
+            if (applied[i] == camera) {
+                isApplied = true;
+                break;
+            }
+        }
+        if (isApplied) {
             continue;
         }
+
         writeLocalCameraPose(*camera, basis);
         applied[appliedCount++] = camera;
     }
@@ -518,16 +527,14 @@ keyframe::CameraTimelineRenderContextHandle makePreviewRenderContext(float parti
     keyframe::setPreviewCameraApplied(true);
     keyframe::setLastPreviewPose(sample->state);
     gParkedObserverCamera = sample->state;
-    return keyframe::publishCameraTimelineRenderContext(
-        keyframe::CameraTimelineRenderContext{
-            *time,
-            keyframe::CameraTimelineSource::Preview,
-            0,
-            std::move(sample),
-            {},
-            serial,
-        }
-    );
+    return keyframe::publishCameraTimelineRenderContext(keyframe::CameraTimelineRenderContext{
+        *time,
+        keyframe::CameraTimelineSource::Preview,
+        0,
+        std::move(sample),
+        {},
+        serial,
+    });
 }
 
 LL_TYPE_INSTANCE_HOOK(

--- a/src/playback/replay/ReplaySession.cpp
+++ b/src/playback/replay/ReplaySession.cpp
@@ -1768,13 +1768,13 @@ bool ReplaySession::prepareChunkInjectionPlan(PlaybackView const& view) {
     };
 
     std::vector<PrioritizedLevelChunk>                    levelChunks;
-    std::unordered_set<ChunkPos>                          levelChunkPositions;
+    std::unordered_map<ChunkPos, size_t>                  levelChunkIndices;
     std::unordered_set<ChunkPos>                          requestModeLevelChunks;
     std::unordered_map<ChunkPos, SnapshotColumnIdentity>  targetColumns;
     std::unordered_map<ChunkPos, std::unordered_set<int>> subChunkIndicesByColumn;
     size_t                                                skippedBlobCachePackets = 0;
     levelChunks.reserve(mPendingLevelChunkIndices.size());
-    levelChunkPositions.reserve(mPendingLevelChunkIndices.size());
+    levelChunkIndices.reserve(mPendingLevelChunkIndices.size());
     requestModeLevelChunks.reserve(mPendingLevelChunkIndices.size());
 
     for (int index : mPendingLevelChunkIndices) {
@@ -1797,11 +1797,8 @@ bool ReplaySession::prepareChunkInjectionPlan(PlaybackView const& view) {
         }
 
         ChunkPos const pos = *levelChunk.mPos;
-        if (!levelChunkPositions.emplace(pos).second) {
-            auto const duplicate = std::find_if(levelChunks.begin(), levelChunks.end(), [&pos](auto const& existing) {
-                return existing.pos == pos;
-            });
-            if (duplicate != levelChunks.end()) duplicate->index = index;
+        if (auto it = levelChunkIndices.find(pos); it != levelChunkIndices.end()) {
+            levelChunks[it->second].index = index;
             if (static_cast<bool>(levelChunk.mClientNeedsToRequestSubchunks)) {
                 requestModeLevelChunks.emplace(pos);
             } else {
@@ -1810,6 +1807,7 @@ bool ReplaySession::prepareChunkInjectionPlan(PlaybackView const& view) {
             targetColumns[pos].levelChunkIndex = index;
             continue;
         }
+        levelChunkIndices.emplace(pos, levelChunks.size());
         if (static_cast<bool>(levelChunk.mClientNeedsToRequestSubchunks)) {
             requestModeLevelChunks.emplace(pos);
         }
@@ -1834,7 +1832,9 @@ bool ReplaySession::prepareChunkInjectionPlan(PlaybackView const& view) {
     }
 
     auto& protectedChunks = mApplyingChunkSnapshot ? mApplyingSnapshotChunks : mSnapshotChunks;
-    protectedChunks.insert(levelChunkPositions.begin(), levelChunkPositions.end());
+    for (auto const& item : levelChunkIndices) {
+        protectedChunks.insert(item.first);
+    }
 
     std::vector<PrioritizedSubChunk> subChunks;
     subChunks.reserve(mPendingSubChunkIndices.size());
@@ -1883,7 +1883,7 @@ bool ReplaySession::prepareChunkInjectionPlan(PlaybackView const& view) {
             if (!isSuccessfulSubChunkResult(result)) continue;
             auto const&    offset = *entry.mSubChunkPosOffset;
             ChunkPos const target{center.x + static_cast<int>(offset.mX), center.z + static_cast<int>(offset.mZ)};
-            if (!levelChunkPositions.contains(target) && !mSnapshotChunks.contains(target)) {
+            if (!levelChunkIndices.contains(target) && !mSnapshotChunks.contains(target)) {
                 if (mApplyingChunkSnapshot) {
                     getLogger().error(
                         "Replay snapshot SubChunk packet {} targets column ({}, {}) without a LevelChunk",

--- a/src/playback/replay/ReplaySession.cpp
+++ b/src/playback/replay/ReplaySession.cpp
@@ -1898,7 +1898,7 @@ bool ReplaySession::prepareChunkInjectionPlan(PlaybackView const& view) {
 
             playableEntries.emplace_back(entry);
             subChunkIndicesByColumn[target].emplace(center.y + static_cast<int>(offset.mY));
-            if (std::find(pending.targets.begin(), pending.targets.end(), target) == pending.targets.end()) {
+            if (pending.targetsSet.insert(target).second) {
                 pending.targets.emplace_back(target);
             }
         }

--- a/src/playback/replay/ReplaySession.h
+++ b/src/playback/replay/ReplaySession.h
@@ -80,11 +80,12 @@ private:
     };
 
     struct PendingSubChunkPacket {
-        int                   index = -1;
-        std::string           payload;
-        std::vector<ChunkPos> targets;
-        std::vector<ChunkPos> dependencies;
-        bool                  injected{};
+        int                          index = -1;
+        std::string                  payload;
+        std::vector<ChunkPos>        targets;
+        std::unordered_set<ChunkPos> targetsSet;
+        std::vector<ChunkPos>        dependencies;
+        bool                         injected{};
     };
 
     struct SnapshotColumnIdentity {


### PR DESCRIPTION
# [perf] Optimize camera and replay lookup paths

This PR includes three minor performance optimizations related to camera rendering and replay chunk processing. All changes avoid linear searches where previously they weren't needed while retaining existing behavior and data ordering.

## Files changed

### 🎥 `src/playback/editor/graphics/CameraRenderHooks.cpp`

* Replaced the `std::find` check for already-applied cameras with a direct loop over the fixed-size applied camera array.
* Preserves the existing duplicate-camera detection behavior.
* Avoids unnecessary iterator/algorithm overhead in the camera render-hook path.
> [!NOTE]
> This is a small micro-optimization because the applied camera array contains at most two entries; it is not expected to produce a significant frame-time improvement.

### 🎞️ `src/playback/replay/ReplaySession.cpp`

* Replaced repeated linear searches through `levelChunks` with an `std::unordered_map` storing each `ChunkPos` and its corresponding vector index.
* Added an `std::unordered_set` for fast duplicate detection of SubChunk target positions.
* Prevents repeated scans of growing vectors when duplicate LevelChunks or SubChunk targets are encountered.
* Keeps the original `levelChunks` and `targets` vectors so their ordering and existing processing behavior remain unchanged.
* Changes duplicate lookup from linear searches to average constant-time hash lookups, reducing CPU work as replay data size and duplicate counts increase.

### 📝 `src/playback/replay/ReplaySession.h`

* Updated the pending chunk injection plan to store LevelChunk indices for direct lookup.
* Added storage for the SubChunk target lookup set used by `ReplaySession.cpp`.

> [!NOTE]
> The main performance benefit comes from the `ReplaySession` changes. Previously, duplicate LevelChunks and SubChunk targets could require repeatedly scanning growing vectors. The new hash-based lookup structures allow the existing entry to be found directly, reducing the amount of work required for large replay data sets.
>
> The camera change is a much smaller hot-path micro-optimization because it only checks a fixed-size array of at most two cameras.

> [!IMPORTANT]
> These changes optimize lookup operations only. They do not intentionally change replay output, chunk ordering, camera behavior, or rendering logic.

## Validation

* [x] `xmake -r -y`
* [x] `git diff --check`
* [x] Tested in Minecraft when the change affects recording, replay, or UI behavior

## Checklist

* [x] The change is focused and contains no unrelated refactoring.
* [x] Changed C++ files have been formatted with the repository configuration.
* [x] Translation keys remain aligned across supported languages where applicable.
* [x] New third-party code or assets include the required license notice.
* [x] Logs, replays, screenshots, and test data contain no private server or player information.